### PR TITLE
Add tab width dropdown selector

### DIFF
--- a/src/request/sign-message/SignMessage.css
+++ b/src/request/sign-message/SignMessage.css
@@ -114,7 +114,24 @@
     outline: none;
     width: 100%;
     padding: 1.5rem;
-    flex-grow: 1;
+    flex-grow: 4;
     resize: none;
     font-family: 'Fira Mono', monospace;
+}
+
+#tabdiv {
+    display: flex;
+    flex-direction: row:
+    flex-grow: 1
+}
+
+#tabtext {
+    margin-left: 1rem;
+    flex-grow: 2;
+}
+
+#tabselect {
+    flex-grow: 1;
+    margin-top: 1rem;
+    margin-bottom : 1rem;
 }

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -35,7 +35,7 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $tabSize = ($page.querySelector("#tabselect"));
 
-		// Loads last used size from localStorage.
+        // Loads last used size from localStorage.
         let loadedSize = localStorage.getItem("tab-size");
         if (!loadedSize) loadedSize = "8";
 
@@ -48,13 +48,13 @@ class SignMessage {
             localStorage.setItem("tab-size", $tabSize.value);
         }
 
-
         // Set message
         if (typeof request.message === 'string') {
             $message.value = request.message;
 
             if (!request.message.includes("\t")) {
-                $tabSize.parentElement.style.display = "none";
+                const parent = $tabSize.parentElement;
+                if (parent) parent.style.display = "none";
             }
         } else {
             $message.value = Nimiq.BufferUtils.toHex(request.message);

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -32,6 +32,9 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $message = ($page.querySelector('#message'));
 
+        /** @type {HTMLInputElement} */
+        const $tabSize = ($page.querySelector("#tabselect"));
+
 		// Loads last used size from localStorage.
         let loadedSize = localStorage.getItem("tab-size");
         if (!loadedSize) loadedSize = "8";

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -32,9 +32,27 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $message = ($page.querySelector('#message'));
 
+		// Loads last used size from localStorage.
+        let loadedSize = localStorage.getItem("tab-size");
+        if (!loadedSize) loadedSize = "8";
+
+        // Sets #tabselect's value and #message's tabSize style property.
+        $tabSize.value = loadedSize;
+        $message.style.tabSize = $tabSize.value;
+        $tabSize.oninput = (e) => {
+            // When #tabselect's value changes, update the value of #message's tabSize and update localStorage.
+            $message.style.tabSize = $tabSize.value;
+            localStorage.setItem("tab-size", $tabSize.value);
+        }
+
+
         // Set message
         if (typeof request.message === 'string') {
             $message.value = request.message;
+
+            if (!request.message.includes("\t")) {
+                $tabSize.parentElement.style.display = "none";
+            }
         } else {
             $message.value = Nimiq.BufferUtils.toHex(request.message);
         }

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -70,6 +70,16 @@
             </div>
 
             <div class="page-body nq-card-body">
+                <div id="tabdiv">
+                    <p id="tabtext"> Tab Width: </p>
+                    <select id="tabselect">
+                        <option value="1"> 1 Space </option>
+                        <option value="2"> 2 Spaces </option>
+                        <option value="4"> 4 Spaces </option>
+                        <option value="8"> 8 Spaces </option>
+                    </select>
+                </div>
+
                 <textarea id="message" readonly="readonly"></textarea>
 
                 <div class="account">


### PR DESCRIPTION
 - Only appears when message is a string containing a tab.
 - Options are 1, 2, 4, and 8 defaulting to 8.
 - Choice is saved in localStorage and recalled when signing in the future.