### PR TITLE
Delay hash change during file export on iOS 13.x+

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard#readme",
   "devDependencies": {
-    "@nimiq/core-web": "1.4.3",
+    "@nimiq/core-web": "1.5.3",
     "@nimiq/rpc": "^0.3.0",
     "@nimiq/style": "^0.7.6",
     "@types/jasmine": "^2.8.8",

--- a/src/components/DownloadLoginFile.css
+++ b/src/components/DownloadLoginFile.css
@@ -13,6 +13,10 @@
     margin: auto;
 }
 
+.download-loginfile.maybe-downloaded .loginfile {
+    height: 38rem;
+}
+
 .download-button .loginfile-link {
     flex-grow: 1;
 }
@@ -53,16 +57,26 @@
     line-height: 7.5rem;
 }
 
+.download-loginfile .download-button > .nq-icon {
+    margin-right: 1.5rem;
+}
+
 .download-loginfile .tap-and-hold,
 .download-loginfile .continue,
+.download-loginfile .back-to-download,
 .download-loginfile.fallback-download .download-button,
 .download-loginfile.maybe-downloaded .download-button {
     display: none;
 }
 
 .download-loginfile.fallback-download .tap-and-hold,
-.download-loginfile.maybe-downloaded .continue {
+.download-loginfile.maybe-downloaded .continue,
+.download-loginfile.maybe-downloaded .back-to-download {
     display: block;
+}
+
+.download-loginfile.maybe-downloaded .back-to-download {
+    margin: 1rem auto -1rem;
 }
 
 .download-loginfile.maybe-downloaded .tap-and-hold {

--- a/src/components/DownloadLoginFile.js
+++ b/src/components/DownloadLoginFile.js
@@ -46,10 +46,16 @@ class DownloadLoginFile extends Nimiq.Observable {
         this.$loginfile.addEventListener('mousedown', e => this._onMouseDown(e));
         this.$loginfile.addEventListener('touchstart', () => this._onTouchStart());
         this.$downloadButton.addEventListener('click', () => this._onDownloadStart());
-        $continueButton.addEventListener('click', this._onDownloadEnd.bind(this));
+        $continueButton.addEventListener('click', () => {
+            this._onDownloadEnd();
+            // Remove previously added classes after a short delay to restore the initial state.
+            window.setTimeout(() => {
+                this.$el.classList.remove('maybe-downloaded');
+                this.fire(DownloadLoginFile.Events.RESET);
+            }, 300);
+        });
         $backToDownloadButton.addEventListener('click', () => {
-            this.$el.classList.remove('maybe-downloaded');
-            this.fire(DownloadLoginFile.Events.RESET);
+            this.$downloadButton.click();
         });
     }
 
@@ -101,6 +107,7 @@ class DownloadLoginFile extends Nimiq.Observable {
         }
         // Remove previously added classes to restore the initial state.
         this.$el.classList.remove('maybe-downloaded');
+        this.fire(DownloadLoginFile.Events.RESET);
 
         const color = IqonHash.getBackgroundColorIndex(firstAddress.toUserFriendlyAddress());
         this.file = new LoginFile(Nimiq.BufferUtils.toBase64(encryptedEntropy), color);
@@ -178,7 +185,7 @@ class DownloadLoginFile extends Nimiq.Observable {
             // If window gets blurred, show 'Continue' button in interface and do not automatically
             // consider the download successful.
             // As mobile Safari on iOS 13.x+ does support the download attribute, it no longer uses the long tap
-            // fallback. However, if the page changes its hash in the background while the promt asking to download
+            // fallback. However, if the page changes its hash in the background while the prompt asking to download
             // the file was not confirmed yet, the download will simply do nothing. To prevent that behaviour the
             // hash change is delayed by the .maybe-downloaded confirmation mechanism.
             if (!document.hasFocus()

--- a/src/components/DownloadLoginFile.js
+++ b/src/components/DownloadLoginFile.js
@@ -49,14 +49,9 @@ class DownloadLoginFile extends Nimiq.Observable {
         $continueButton.addEventListener('click', () => {
             this._onDownloadEnd();
             // Remove previously added classes after a short delay to restore the initial state.
-            window.setTimeout(() => {
-                this.$el.classList.remove('maybe-downloaded');
-                this.fire(DownloadLoginFile.Events.RESET);
-            }, 300);
+            window.setTimeout(this._reset.bind(this), 300);
         });
-        $backToDownloadButton.addEventListener('click', () => {
-            this.$downloadButton.click();
-        });
+        $backToDownloadButton.addEventListener('click', () => this.$downloadButton.click());
     }
 
     /**
@@ -106,8 +101,7 @@ class DownloadLoginFile extends Nimiq.Observable {
             throw new Errors.KeyguardError('Can only export encrypted Entropies');
         }
         // Remove previously added classes to restore the initial state.
-        this.$el.classList.remove('maybe-downloaded');
-        this.fire(DownloadLoginFile.Events.RESET);
+        this._reset();
 
         const color = IqonHash.getBackgroundColorIndex(firstAddress.toUserFriendlyAddress());
         this.file = new LoginFile(Nimiq.BufferUtils.toBase64(encryptedEntropy), color);
@@ -189,9 +183,7 @@ class DownloadLoginFile extends Nimiq.Observable {
             // the file was not confirmed yet, the download will simply do nothing. To prevent that behaviour the
             // hash change is delayed by the .maybe-downloaded confirmation mechanism.
             if (!document.hasFocus()
-                || (BrowserDetection.isIOS()
-                    && BrowserDetection.isSafari()
-                    && BrowserDetection.iOSVersion()[0] > 12)) {
+                || (BrowserDetection.isIOS() && BrowserDetection.iOSVersion()[0] > 12)) {
                 this.$el.classList.add('maybe-downloaded');
                 this.fire(DownloadLoginFile.Events.INITIATED);
                 return;
@@ -239,6 +231,11 @@ class DownloadLoginFile extends Nimiq.Observable {
             this.$longTouchIndicator.style.display = 'none';
             this.$longTouchIndicator.classList.remove('animate');
         }
+    }
+
+    _reset() {
+        this.$el.classList.remove('maybe-downloaded');
+        this.fire(DownloadLoginFile.Events.RESET);
     }
 
     get file() {

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -214,7 +214,9 @@ ul.nq-list li > .nq-icon {
 .page#recovery-words .page-header .page-header-back-button,
 .page#login-file-download .page-header,
 .page#login-file-download button,
-.page#login-file-download .download-button {
+.page#login-file-download .download-button,
+.page#login-file-download .continue,
+.page#login-file-download .back-to-download {
     opacity: 0;
 }
 

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -164,6 +164,11 @@ ul.nq-list li > .nq-icon {
     filter: blur(20px);
 }
 
+.page#login-file-download.loginfile-download-initiated .page-header .nq-h1:not(.confirm-download),
+.page#login-file-download:not(.loginfile-download-initiated) .page-header .confirm-download {
+    display: none;
+}
+
 .page#recovery-words .page-header .warning,
 .page#recovery-words .words-container {
     transition: filter .6s, opacity .6s;

--- a/src/request/export/ExportFile.js
+++ b/src/request/export/ExportFile.js
@@ -221,7 +221,15 @@ class ExportFile extends Nimiq.Observable {
                 /** @type {Nimiq.SerialBuffer} */ (encryptedSecret),
                 key.defaultAddress,
             );
-
+            // reset initial state
+            this.$downloadFilePage.classList.remove(DownloadLoginFile.Events.INITIATED);
+            // add Events
+            this._downloadLoginFile.on(DownloadLoginFile.Events.INITIATED, () => {
+                this.$downloadFilePage.classList.add(DownloadLoginFile.Events.INITIATED);
+            });
+            this._downloadLoginFile.on(DownloadLoginFile.Events.RESET, () => {
+                this.$downloadFilePage.classList.remove(DownloadLoginFile.Events.INITIATED);
+            });
             this._downloadLoginFile.on(DownloadLoginFile.Events.DOWNLOADED, () => {
                 this._resolve({ success: true });
             });

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -317,6 +317,7 @@
                         <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-arrow-left"/></svg>
                     </a>
                     <h1 class="nq-h1" data-i18n="import-words-download-loginfile">Save your Login File</h1>
+                    <h1 class="nq-h1 confirm-download " data-i18n="download-loginfile-successful">Download successful?</h1>
                 </div>
 
                 <div class="page-body nq-card-body">

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -74,8 +74,10 @@ const TRANSLATIONS = {
         'identicon-selector-generate-new': 'New Avatars',
 
         'download-loginfile-download': 'Download Login File',
+        'download-loginfile-successful': 'Download successful?',
         'download-loginfile-tap-and-hold': 'Tap and hold image to download',
-        'download-loginfile-continue': 'Continue',
+        'download-loginfile-continue': 'Continue when ready',
+        'download-loginfile-download-again': 'Download again',
 
         'validate-words-text': 'Please select the correct word from your list of recovery words.',
         'validate-words-1-hint': 'What is the 1st word?',
@@ -229,8 +231,10 @@ const TRANSLATIONS = {
         'identicon-selector-generate-new': 'Neue Avatare',
 
         'download-loginfile-download': 'Login File herunterladen',
+        'download-loginfile-successful': 'Download erfolgreich?',
         'download-loginfile-tap-and-hold': 'Zum Herunterladen Bild gedrückt halten',
         'download-loginfile-continue': 'Weiter',
+        'download-loginfile-download-again': 'Erneut herunterladen',
 
         'validate-words-text': 'Bitte wähle das richtige Wort aus deiner Liste von Wiederherstellungswörtern aus.',
         'validate-words-1-hint': 'Was ist das 1. Wort?',

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -99,11 +99,11 @@ output "🧐  Validating Nimiq Core files integrity"
 
 # For Nimiq Core v1.4.3
 hashsums=\
-"131abbc8c240d8c887bb48370f0c8d902d2a8f3a40ffb2aa629b98add599c9b6  node_modules/@nimiq/core-web/web-offline.js
+"2fc34cc4e1a42164417a1d8b108148e2c52ad26fa6e6c22e056659cad28d4810  node_modules/@nimiq/core-web/web-offline.js
  a658ca600c43789c8daff47578ea5758e7a1a2a5fee1b249e7bb5ce691d126cd  node_modules/@nimiq/core-web/worker-wasm.wasm
  d61df01adc927cb2832314ef5634b9ea97092acacb09beb7628b1a98a0962c70  node_modules/@nimiq/core-web/worker-wasm.js
  154b1251428363c8658c99acbf55b31eef177c0d447767a506952924a37494a9  node_modules/@nimiq/core-web/worker-js.js
- 5670830478ac20a634b1436cd24cc3ba2eda23e8f8a7a30f54958920046435ce  node_modules/@nimiq/core-web/worker.js"
+ 2123d109821661e758f091676670f29d905c7e24a177757288aaefcf59fefdda  node_modules/@nimiq/core-web/worker.js"
 
 echo "$hashsums" | ${SHA256SUM} --check
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@nimiq/core-web@1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
-  integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
+"@nimiq/core-web@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.5.3.tgz#f0a4de59394f210f2c2d9cda8ee35c716847d40e"
+  integrity sha512-W66SS9n3ygYgD52r1GJr1WtYYOkcZsqdtMmDCEwDvkrmeARnHs2sAvj77Wt4PQG8JA7GwK5svIJr6rGccCaekw==
 
 "@nimiq/rpc@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
While Safari on iOS 13 does support the download attribute, the resulting download prompt does not like the hash change  in the background happening in our setup. 
This PR changes that behaviour by delaying the hash change until after the prompt was confirmed.

This PR also increases core-web to Version 1.5.3.

Resolves #382