### PR TITLE
Tab-width selector

### DIFF
--- a/src/components/TabWidthSelector.css
+++ b/src/components/TabWidthSelector.css
@@ -1,0 +1,24 @@
+.tab-width-selector span {
+    opacity: 0.4;
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-right: 1rem;
+}
+
+.tab-width-selector button {
+    padding: 0;
+    width: 3.375rem;
+    background: none;
+}
+
+.tab-width-selector.width-2 button[data-width="2"],
+.tab-width-selector.width-4 button[data-width="4"],
+.tab-width-selector.width-8 button[data-width="8"] {
+    color: var(--nimiq-blue-darkened);
+    background: rgba(31,35,72,.12); /* Taken from .nq-button-s:hover rule */
+}
+
+.tab-width-selector button::before {
+    /* Disable touch area because it would overlap the neighboring buttons. */
+    display: none;
+}

--- a/src/components/TabWidthSelector.js
+++ b/src/components/TabWidthSelector.js
@@ -36,7 +36,7 @@ class TabWidthSelector extends Nimiq.Observable {
 
         /* eslint-disable max-len */
         $el.innerHTML = TemplateTags.noVars`
-            <span data-i18n="tabwidthselector-label">Tab Width</span>
+            <span data-i18n="tab-width-selector-label">Tab Width</span>
             <button class="nq-button-s" data-width="2">2</button>
             <button class="nq-button-s" data-width="4">4</button>
             <button class="nq-button-s" data-width="8">8</button>

--- a/src/components/TabWidthSelector.js
+++ b/src/components/TabWidthSelector.js
@@ -1,0 +1,85 @@
+/* global Nimiq */
+/* global I18n */
+/* global TemplateTags */
+
+class TabWidthSelector extends Nimiq.Observable {
+    /**
+     * @param {?HTMLElement} $el
+     */
+    constructor($el) {
+        super();
+
+        this.$el = TabWidthSelector._createElement($el);
+
+        // Load last used width from localStorage.
+        this._tabWidth = localStorage.getItem(TabWidthSelector.LOCALSTORAGE_KEY) || TabWidthSelector.DEFAULT_TAB_WIDTH;
+        this._updateClasses();
+
+        this.$width2Button = /** @type {HTMLButtonElement} */ (this.$el.querySelector('button[data-width="2"]'));
+        this.$width4Button = /** @type {HTMLButtonElement} */ (this.$el.querySelector('button[data-width="4"]'));
+        this.$width8Button = /** @type {HTMLButtonElement} */ (this.$el.querySelector('button[data-width="8"]'));
+
+        this._onSelection = this._onSelection.bind(this);
+
+        this.$width2Button.addEventListener('click', this._onSelection);
+        this.$width4Button.addEventListener('click', this._onSelection);
+        this.$width8Button.addEventListener('click', this._onSelection);
+    }
+
+    /**
+     * @param {?HTMLElement} [$el]
+     * @returns {HTMLElement}
+     */
+    static _createElement($el) {
+        $el = $el || document.createElement('div');
+        $el.classList.add('tab-width-selector');
+
+        /* eslint-disable max-len */
+        $el.innerHTML = TemplateTags.noVars`
+            <span data-i18n="tabwidthselector-label">Tab Width</span>
+            <button class="nq-button-s" data-width="2">2</button>
+            <button class="nq-button-s" data-width="4">4</button>
+            <button class="nq-button-s" data-width="8">8</button>
+        `;
+        /* eslint-enable max-len */
+
+        I18n.translateDom($el);
+        return $el;
+    }
+
+    get width() {
+        return this._tabWidth;
+    }
+
+    /**
+     * @param {Event} event
+     */
+    _onSelection(event) {
+        if (!event.target) return;
+        const width = /** @type {HTMLButtonElement} */ (event.target).dataset.width;
+        if (!width) return; // For Typescript, as the width could be 'undefined' in the dataset
+        this._updateWidth(width);
+    }
+
+    /**
+     * @param {string} width
+     */
+    _updateWidth(width) {
+        this._tabWidth = width;
+        this._updateClasses();
+        localStorage.setItem(TabWidthSelector.LOCALSTORAGE_KEY, this._tabWidth);
+        this.fire(TabWidthSelector.Events.INPUT, this._tabWidth);
+    }
+
+    _updateClasses() {
+        this.$el.classList.remove('width-2', 'width-4', 'width-8');
+        this.$el.classList.add(`width-${this._tabWidth}`);
+    }
+}
+
+TabWidthSelector.LOCALSTORAGE_KEY = 'tab-width';
+TabWidthSelector.DEFAULT_TAB_WIDTH = '4';
+
+TabWidthSelector.Events = {
+    INPUT: 'tabwidthselector-input',
+};

--- a/src/request/sign-message/SignMessage.css
+++ b/src/request/sign-message/SignMessage.css
@@ -114,7 +114,24 @@
     outline: none;
     width: 100%;
     padding: 1.5rem;
-    flex-grow: 1;
+    flex-grow: 4;
     resize: none;
     font-family: 'Fira Mono', monospace;
+}
+
+#tabdiv {
+    display: flex;
+    flex-direction: row:
+    flex-grow: 1
+}
+
+#tabtext {
+    margin-left: 1rem;
+    flex-grow: 2;
+}
+
+#tabselect {
+    flex-grow: 1;
+    margin-top: 1rem;
+    margin-bottom : 1rem;
 }

--- a/src/request/sign-message/SignMessage.css
+++ b/src/request/sign-message/SignMessage.css
@@ -114,24 +114,26 @@
     outline: none;
     width: 100%;
     padding: 1.5rem;
-    flex-grow: 4;
+    flex-grow: 1;
     resize: none;
     font-family: 'Fira Mono', monospace;
 }
 
-#tabdiv {
-    display: flex;
-    flex-direction: row:
-    flex-grow: 1
+.tab-width {
+    text-align: right;
+    padding: 0.5rem;
+    background-color: rgba(31, 35, 72, .05); /* Based on Nimiq Blue */
+    border: solid 1px rgba(31, 35, 72, .1); /* Based on Nimiq Blue */
+    border-top: none;
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
 }
 
-#tabtext {
-    margin-left: 1rem;
-    flex-grow: 2;
+.page#sign-message:not(.show-tab-width-selector) .tab-width {
+    display: none;
 }
 
-#tabselect {
-    flex-grow: 1;
-    margin-top: 1rem;
-    margin-bottom : 1rem;
+.page#sign-message.show-tab-width-selector #message {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 }

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -42,7 +42,7 @@ class SignMessage {
                 // Init tab width selector
 
                 /** @type {HTMLDivElement} */
-                const $tabWidthSelector = ($page.querySelector('#tabwidthselector'));
+                const $tabWidthSelector = ($page.querySelector('#tab-width-selector'));
                 const tws = new TabWidthSelector($tabWidthSelector);
 
                 // @ts-ignore Property 'tabSize' does not exist on type 'CSSStyleDeclaration'

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -35,7 +35,7 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $tabSize = ($page.querySelector("#tabselect"));
 
-		// Loads last used size from localStorage.
+        // Loads last used size from localStorage.
         let loadedSize = localStorage.getItem("tab-size");
         if (!loadedSize) loadedSize = "8";
 
@@ -48,13 +48,13 @@ class SignMessage {
             localStorage.setItem("tab-size", $tabSize.value);
         }
 
-
         // Set message
         if (typeof request.message === 'string') {
             $message.value = request.message;
 
             if (!request.message.includes("\t")) {
-                $tabSize.parentElement.style.display = "none";
+                const parent = $tabSize.parentElement;
+                if (parent) parent.style.display = "none";
             }
         } else {
             $message.value = Nimiq.BufferUtils.toHex(request.message);

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -1,6 +1,7 @@
 /* global Nimiq */
 /* global Key */
 /* global KeyStore */
+/* global TabWidthSelector */
 /* global Identicon */
 /* global PasswordBox */
 /* global Utf8Tools */
@@ -32,29 +33,27 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $message = ($page.querySelector('#message'));
 
-        /** @type {HTMLInputElement} */
-        const $tabSize = ($page.querySelector("#tabselect"));
-
-        // Loads last used size from localStorage.
-        let loadedSize = localStorage.getItem("tab-size");
-        if (!loadedSize) loadedSize = "8";
-
-        // Sets #tabselect's value and #message's tabSize style property.
-        $tabSize.value = loadedSize;
-        $message.style.tabSize = $tabSize.value;
-        $tabSize.oninput = (e) => {
-            // When #tabselect's value changes, update the value of #message's tabSize and update localStorage.
-            $message.style.tabSize = $tabSize.value;
-            localStorage.setItem("tab-size", $tabSize.value);
-        }
-
         // Set message
         if (typeof request.message === 'string') {
             $message.value = request.message;
 
-            if (!request.message.includes("\t")) {
-                const parent = $tabSize.parentElement;
-                if (parent) parent.style.display = "none";
+            // Look for tabs
+            if (request.message.includes('\t')) {
+                // Init tab width selector
+
+                /** @type {HTMLDivElement} */
+                const $tabWidthSelector = ($page.querySelector('#tabwidthselector'));
+                const tws = new TabWidthSelector($tabWidthSelector);
+
+                // @ts-ignore Property 'tabSize' does not exist on type 'CSSStyleDeclaration'
+                $message.style.tabSize = tws.width;
+
+                tws.on(TabWidthSelector.Events.INPUT, width => {
+                    // @ts-ignore Property 'tabSize' does not exist on type 'CSSStyleDeclaration'
+                    $message.style.tabSize = width;
+                });
+
+                $page.classList.add('show-tab-width-selector');
             }
         } else {
             $message.value = Nimiq.BufferUtils.toHex(request.message);

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -32,6 +32,9 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $message = ($page.querySelector('#message'));
 
+        /** @type {HTMLInputElement} */
+        const $tabSize = ($page.querySelector("#tabselect"));
+
 		// Loads last used size from localStorage.
         let loadedSize = localStorage.getItem("tab-size");
         if (!loadedSize) loadedSize = "8";

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -32,9 +32,27 @@ class SignMessage {
         /** @type {HTMLInputElement} */
         const $message = ($page.querySelector('#message'));
 
+		// Loads last used size from localStorage.
+        let loadedSize = localStorage.getItem("tab-size");
+        if (!loadedSize) loadedSize = "8";
+
+        // Sets #tabselect's value and #message's tabSize style property.
+        $tabSize.value = loadedSize;
+        $message.style.tabSize = $tabSize.value;
+        $tabSize.oninput = (e) => {
+            // When #tabselect's value changes, update the value of #message's tabSize and update localStorage.
+            $message.style.tabSize = $tabSize.value;
+            localStorage.setItem("tab-size", $tabSize.value);
+        }
+
+
         // Set message
         if (typeof request.message === 'string') {
             $message.value = request.message;
+
+            if (!request.message.includes("\t")) {
+                $tabSize.parentElement.style.display = "none";
+            }
         } else {
             $message.value = Nimiq.BufferUtils.toHex(request.message);
         }

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -43,6 +43,7 @@
 
     <script defer src="../../lib/IqonHash.js"></script>
     <script defer src="../../lib/Iqons.js"></script>
+    <script defer src="../../components/TabWidthSelector.js"></script>
     <script defer src="../../components/Identicon.js"></script>
     <script defer src="SignMessageApi.js"></script>
     <script defer src="SignMessage.js"></script>
@@ -51,6 +52,7 @@
     <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
     <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
     <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/TabWidthSelector.css">
     <link rel="stylesheet" bundle-toplevel href="../../components/PasswordInput.css">
     <link rel="stylesheet" bundle-toplevel href="../../components/PasswordBox.css">
 
@@ -70,17 +72,10 @@
             </div>
 
             <div class="page-body nq-card-body">
-                <div id="tabdiv">
-                    <p id="tabtext"> Tab Width: </p>
-                    <select id="tabselect">
-                        <option value="1"> 1 Space </option>
-                        <option value="2"> 2 Spaces </option>
-                        <option value="4"> 4 Spaces </option>
-                        <option value="8"> 8 Spaces </option>
-                    </select>
-                </div>
-
                 <textarea id="message" readonly="readonly"></textarea>
+                <div class="tab-width">
+                    <div id="tabwidthselector"></div>
+                </div>
 
                 <div class="account">
                     <div class="identicon" id="signer-identicon"></div>

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -74,7 +74,7 @@
             <div class="page-body nq-card-body">
                 <textarea id="message" readonly="readonly"></textarea>
                 <div class="tab-width">
-                    <div id="tabwidthselector"></div>
+                    <div id="tab-width-selector"></div>
                 </div>
 
                 <div class="account">

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -70,6 +70,16 @@
             </div>
 
             <div class="page-body nq-card-body">
+                <div id="tabdiv">
+                    <p id="tabtext"> Tab Width: </p>
+                    <select id="tabselect">
+                        <option value="1"> 1 Space </option>
+                        <option value="2"> 2 Spaces </option>
+                        <option value="4"> 4 Spaces </option>
+                        <option value="8"> 8 Spaces </option>
+                    </select>
+                </div>
+
                 <textarea id="message" readonly="readonly"></textarea>
 
                 <div class="account">

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -48,7 +48,7 @@ const TRANSLATIONS = {
 
         'sign-msg-heading': 'Sign Message',
 
-        'tabwidthselector-label': 'Tab Width',
+        'tab-width-selector-label': 'Tab Width',
 
         'address-info-new-cashlink': 'New Cashlink',
 
@@ -219,7 +219,7 @@ const TRANSLATIONS = {
 
         'sign-msg-heading': 'Nachricht signieren',
 
-        'tabwidthselector-label': 'Tab-Breite',
+        'tab-width-selector-label': 'Tab-Breite',
 
         'address-info-new-cashlink': 'Neuer Cashlink',
 

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -48,6 +48,8 @@ const TRANSLATIONS = {
 
         'sign-msg-heading': 'Sign Message',
 
+        'tabwidthselector-label': 'Tab Width',
+
         'address-info-new-cashlink': 'New Cashlink',
 
         'passwordbox-enter-password': 'Enter your password',
@@ -216,6 +218,8 @@ const TRANSLATIONS = {
         'sign-tx-cancel-payment': 'Zahlung abbrechen',
 
         'sign-msg-heading': 'Nachricht signieren',
+
+        'tabwidthselector-label': 'Tab-Breite',
 
         'address-info-new-cashlink': 'Neuer Cashlink',
 


### PR DESCRIPTION
First proposed by @MatthewDLudwig in #368.

Add a tab-width selector component to the sign-message UI, when the message contains tabs (`\t`). The selected tab-width is stored in localStorage and automatically applied next time.

The component is styled according to Julians design (https://github.com/nimiq/keyguard/pull/368#issuecomment-549115231).

Closes https://github.com/nimiq/hub/issues/204.