### PR TITLE
Improve error for Keyguard iframe with unexpected src

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,40 @@
+stages:
+  - build
+  - test
+  - docker
+  - deploy
+
+# include private configs for the remaining stages
+include:
+  - project: "it/ci-config"
+    file: "/testnet/deploy_webapp.yml"
+
+build:
+  stage: build
+  image: node:lts
+  artifacts:
+    paths:
+      - dist/
+  cache:
+    key: node-cache
+    paths:
+      - node_modules/
+  script:
+    - yarn install
+    - yarn build
+    # Make sure the dist directory exists, so that _this_ job fails and not the next one
+    - test -d dist || (echo "No dist directory\!" && exit 1)
+    - test -f dist/index.html || (echo "No files in dist\!" && exit 1)
+  allow_failure: false
+
+test:
+  stage: test
+  image: node:lts
+  cache:
+    key: node-cache
+    paths:
+      - node_modules/
+  script:
+    - yarn lint
+  allow_failure: true
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,21 @@ include:
   - project: "it/ci-config"
     file: "/testnet/deploy_webapp.yml"
 
+variables:
+  # nginx configuration for this webapp
+  NGINX_CONFIG: |
+    server {
+        listen       80;
+        listen  [::]:80;
+        server_name  localhost;
+
+        location / {
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
+          try_files $$uri $$uri/ =404;
+        }
+    }
+
 build:
   stage: build
   image: node:lts

--- a/client/src/RequestBehavior.ts
+++ b/client/src/RequestBehavior.ts
@@ -74,8 +74,14 @@ export class IFrameRequestBehavior extends RequestBehavior {
     }
 
     public async request(endpoint: string, command: KeyguardCommand, args: any[]): Promise<any> {
-        if (this._iframe && this._iframe.src !== `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`) {
-            throw new Error('Keyguard iframe is already opened with another endpoint');
+        if (this._iframe
+            && this._iframe.src
+            && this._iframe.src !== `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`
+        ) {
+            const openedSrc = this._iframe.src;
+            const expectedSrc = `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`;
+            throw new Error('Keyguard iframe is already opened with another endpoint' +
+                `(opened: ${openedSrc}, expected: ${expectedSrc}`);
         }
 
         const origin = RequestBehavior.getAllowedOrigin(endpoint);

--- a/client/src/RequestBehavior.ts
+++ b/client/src/RequestBehavior.ts
@@ -64,45 +64,27 @@ export class RedirectRequestBehavior extends RequestBehavior {
 export class IFrameRequestBehavior extends RequestBehavior {
     private static IFRAME_PATH_SUFFIX = '/request/iframe/';
 
-    private _iframe: HTMLIFrameElement | null;
-    private _client: PostMessageRpcClient | null;
+    private _iframeEndpoint: string | null = null;
+    private _iframePromise: Promise<HTMLIFrameElement> | null = null;
+    private _clientPromise: Promise<PostMessageRpcClient> | null = null;
 
     constructor() {
         super(BehaviorType.IFRAME);
-        this._iframe = null;
-        this._client = null;
     }
 
     public async request(endpoint: string, command: KeyguardCommand, args: any[]): Promise<any> {
-        if (this._iframe
-            && this._iframe.src
-            && this._iframe.src !== `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`
-        ) {
-            const openedSrc = this._iframe.src;
-            const expectedSrc = `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`;
-            throw new Error('Keyguard iframe is already opened with another endpoint' +
-                `(opened: ${openedSrc}, expected: ${expectedSrc}`);
-        }
-
-        const origin = RequestBehavior.getAllowedOrigin(endpoint);
-
-        if (!this._iframe) {
-            this._iframe = await this.createIFrame(endpoint);
-        }
-        if (!this._iframe.contentWindow) {
-            throw new Error(`IFrame contentWindow is ${typeof this._iframe.contentWindow}`);
-        }
-
-        if (!this._client) {
-            this._client = new PostMessageRpcClient(this._iframe.contentWindow, origin);
-            await this._client.init();
-        }
-
-        return await this._client.call(command, ...args);
+        const client = await this._getClient(endpoint);
+        return client.call(command, ...args);
     }
 
     public async createIFrame(endpoint: string): Promise<HTMLIFrameElement> {
-        return new Promise((resolve, reject) => {
+        if (this._iframeEndpoint && this._iframeEndpoint !== endpoint) {
+            throw new Error('Keyguard iframe is already opened with another endpoint' +
+                `(opened: ${this._iframeEndpoint}, expected: ${endpoint})`);
+        }
+        this._iframeEndpoint = endpoint;
+
+        this._iframePromise = this._iframePromise || new Promise((resolve, reject) => {
             const $iframe = document.createElement('iframe');
             $iframe.name = 'NimiqKeyguardIFrame';
             $iframe.style.display = 'none';
@@ -110,6 +92,25 @@ export class IFrameRequestBehavior extends RequestBehavior {
             $iframe.src = `${endpoint}${IFrameRequestBehavior.IFRAME_PATH_SUFFIX}`;
             $iframe.onload = () => resolve($iframe);
             $iframe.onerror = reject;
-        }) as Promise<HTMLIFrameElement>;
+        });
+
+        return this._iframePromise;
+    }
+
+    private _getClient(endpoint: string): Promise<PostMessageRpcClient> {
+        this._clientPromise = this._clientPromise || new Promise(async (resolve) => {
+            const iframe = await this.createIFrame(endpoint);
+            if (!iframe.contentWindow) {
+                throw new Error(`IFrame contentWindow is ${typeof iframe.contentWindow}`);
+            }
+
+            const origin = RequestBehavior.getAllowedOrigin(endpoint);
+            const client = new PostMessageRpcClient(iframe.contentWindow, origin);
+            await client.init();
+
+            resolve(client);
+        });
+
+        return this._clientPromise;
     }
 }


### PR DESCRIPTION
https://sentry.io/organizations/nimiq/issues/1584763523/

Error: `Keyguard iframe is already opened with another endpoint`

Sometimes it happens that the `WalletInfoCollector` in the Hub fails to derive a batch of addresses, due to the KeyguardClient failing to forward the request to the iframe due to an iframe src error.

This PR is based on the **assumption**, that the src is never the wrong one, but instead is not readable by the Hub context. Thus this PR adds a check for the `_iframe.src` being falsy (`null|undefined|''`) and skips that condition. For genuine missmatches, the error is made more explicit and includes the actual and expected src.

The root cause of the issue might also be another one entirely, based on the process of the WalletInfoCollector. I have not investigated this further, but it _might be_ the case that the Collector triggers a second batch of address derivations _before_ the iframe had a chance to load, thus the src being empty (and thus not matching the expected src).