### PR TITLE
i18n/FlippableHandler: Automatically adapt the height of the element to fit it’s content

### DIFF
--- a/src/components/FlippableHandler.css
+++ b/src/components/FlippableHandler.css
@@ -7,9 +7,9 @@
     width: 100%;
     max-width: 56.5rem; /* 420px + 2 * 2rem because of .nq-card margin*/
     height: 70.5rem; /* 564px */
-    transition: transform 0.6s;
+    transition: transform 0.6s, height 0.6s;
     transform-style: preserve-3d;
-    will-change: transform;
+    will-change: transform, height;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/FlippableHandler.js
+++ b/src/components/FlippableHandler.js
@@ -48,12 +48,10 @@ class FlippableHandler {
                             window.setTimeout(() => $rotationContainer.classList.remove('disable-transition'), 10);
                         }, 0);
                     } else {
+                        $rotationContainer.classList.add('disable-transition');
+                        FlippableHandler._updateContainerHeight($newEl || undefined);
                         window.setTimeout(() => {
-                            $rotationContainer.classList.add('disable-transition');
-                            FlippableHandler._updateContainerHeight($newEl || undefined);
-                            window.setTimeout(() => {
-                                $rotationContainer.classList.remove('disable-transition');
-                            }, 0);
+                            $rotationContainer.classList.remove('disable-transition');
                         }, 0);
                     }
                 }
@@ -65,7 +63,7 @@ class FlippableHandler {
     /**
      * Update the height of the #rotation-container element to match its content.
      * The default behavior is to look for every visible `.page` element,
-     * and, if there is multiple, take the height of the higher.
+     * and, if there are multiple, take the height of the higher.
      * @param {Element} [$enforcedElement] - Enforce which element the function is taking the height from.
      *  Must be a child of `#rotation-container`
      */
@@ -78,7 +76,7 @@ class FlippableHandler {
             /** @type {Array<HTMLElement>} */
             const $pages = Array.from($rotationContainer.querySelectorAll('.page'));
             if ($pages && $pages.length > 0) {
-                const heights = $pages.map($el => ($el.offsetParent ? $el.clientHeight : 0));
+                const heights = $pages.map($el => $el.clientHeight);
                 const visiblePageHeight = Math.max(...heights);
                 $rotationContainer.style.height = visiblePageHeight > 0 ? `${visiblePageHeight}px` : '';
             }

--- a/src/components/FlippableHandler.js
+++ b/src/components/FlippableHandler.js
@@ -78,13 +78,9 @@ class FlippableHandler {
             /** @type {Array<HTMLElement>} */
             const $pages = Array.from($rotationContainer.querySelectorAll('.page'));
             if ($pages && $pages.length > 0) {
-                const $visiblePageHeight = $pages.reduce(
-                    (acc, $el) => ($el.offsetParent && $el.clientHeight > acc ? $el.clientHeight : acc),
-                    0,
-                );
-                if ($visiblePageHeight > 0) {
-                    $rotationContainer.style.height = `${$visiblePageHeight}px`;
-                }
+                const heights = $pages.map($el => ($el.offsetParent ? $el.clientHeight : 0));
+                const visiblePageHeight = Math.max(...heights);
+                $rotationContainer.style.height = visiblePageHeight > 0 ? `${visiblePageHeight}px` : '';
             }
         }
     }

--- a/src/components/FlippableHandler.js
+++ b/src/components/FlippableHandler.js
@@ -12,6 +12,7 @@ class FlippableHandler {
                 const $page = document.querySelector(window.location.hash);
                 if ($page) {
                     $rotationContainer.classList.add('disable-transition');
+                    FlippableHandler._updateContainerHeight($page);
                     window.setTimeout(() => {
                         $rotationContainer.classList.toggle('flipped', $page.classList.contains(classname));
                         window.setTimeout(() => $rotationContainer.classList.remove('disable-transition'), 10);
@@ -32,20 +33,59 @@ class FlippableHandler {
                         window.setTimeout(() => $oldEl.classList.remove('display-flex'), 300);
                         window.setTimeout(() => {
                             $rotationContainer.classList.toggle('flipped', $newEl.classList.contains(classname));
+                            FlippableHandler._updateContainerHeight($newEl);
                         }, 0);
+                    } else {
+                        FlippableHandler._updateContainerHeight($newEl || undefined);
                     }
                 } else if (newHash) {
                     const $newEl = document.querySelector(newHash);
                     if ($newEl && $newEl.classList.contains(classname)) {
                         $rotationContainer.classList.add('disable-transition');
+                        FlippableHandler._updateContainerHeight($newEl);
                         window.setTimeout(() => {
                             $rotationContainer.classList.toggle('flipped', $newEl.classList.contains(classname));
                             window.setTimeout(() => $rotationContainer.classList.remove('disable-transition'), 10);
+                        }, 0);
+                    } else {
+                        window.setTimeout(() => {
+                            $rotationContainer.classList.add('disable-transition');
+                            FlippableHandler._updateContainerHeight($newEl || undefined);
+                            window.setTimeout(() => {
+                                $rotationContainer.classList.remove('disable-transition');
+                            }, 0);
                         }, 0);
                     }
                 }
             });
             FlippableHandler.flippableHandlerInitialised = true;
+        }
+    }
+
+    /**
+     * Update the height of the #rotation-container element to match its content.
+     * The default behavior is to look for every visible `.page` element,
+     * and, if there is multiple, take the height of the higher.
+     * @param {Element} [$enforcedElement] - Enforce which element the function is taking the height from.
+     *  Must be a child of `#rotation-container`
+     */
+    static _updateContainerHeight($enforcedElement) {
+        /** @type {HTMLElement} */
+        const $rotationContainer = (document.getElementById('rotation-container'));
+        if ($enforcedElement && $rotationContainer.contains($enforcedElement)) {
+            $rotationContainer.style.height = `${$enforcedElement.clientHeight}px`;
+        } else {
+            /** @type {Array<HTMLElement>} */
+            const $pages = Array.from($rotationContainer.querySelectorAll('.page'));
+            if ($pages && $pages.length > 0) {
+                const $visiblePageHeight = $pages.reduce(
+                    (acc, $el) => ($el.offsetParent && $el.clientHeight > acc ? $el.clientHeight : acc),
+                    0,
+                );
+                if ($visiblePageHeight > 0) {
+                    $rotationContainer.style.height = `${$visiblePageHeight}px`;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Because of i18n some translations caused the content to overflow on the bottom, and that broke design. With this commit now it automatically adapt the height of the `#rotation-container` element so that it fit its content and do not break design anymore.


_Btw, in the `FlippableHandler` you used a lot `window.setTimeout(..., 0)`.
Is there a reason you used this instead of `requestAnimationFrame` ?_