### PR TITLE
Add static server script to run `yarn serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ yarn
 
 Then you can:
 
+- serve the Keyguard locally with `yarn serve` (starts on port 8000).
 - run the build script with `yarn build [config]`.
 - run the tests with `yarn test`.
 - run the typechecker with `yarn typecheck`.
@@ -25,12 +26,10 @@ Then you can:
 - run `yarn pr` to run all three checks (`typecheck`, `lint`, `test`) as they
   would for a PR.
 
-For local testing of the Keyguard you can setup a local server, for example using
-[`python -m http.server 8000`](https://docs.python.org/3/library/http.server.html#http-server-cli).
 Note that it is mostly not necessary to run the build script for development purposes, as the code in `src` is fully
-functional and you can use it as an endpoint. Only (re)generating the translation dictionary needs to be triggered
-manually via `yarn i18n:build-dictionary`. For convenient testing of the Keyguard there are demos provided under
-`/demos`.
+functional and you can use it as an endpoint. Only regenerating the translation dictionary needs to be triggered
+manually by restarting `yarn serve` or by running `yarn i18n:build-dictionary`.
+For convenient testing of the Keyguard there are demos provided under `/demos`.
 
 ## Coding Style
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Secure storage for Nimiq private keys.",
   "scripts": {
+    "serve": "yarn i18n:build-dictionary && node serve.js",
     "build": "yarn i18n:build-dictionary && tools/build.sh",
     "test": "karma start",
     "typecheck": "tsc",

--- a/serve.js
+++ b/serve.js
@@ -1,0 +1,110 @@
+#!/usr/bin/node
+
+// Adapted from https://gist.github.com/fmal/d56384264eec583eda93
+
+var http = require("http"),
+    url  = require("url"),
+    path = require("path"),
+    fs   = require("fs"),
+    port = process.argv[2] || 8000,
+
+    mimeTypes = {
+      'asc'   : 'text/plain',
+      'au'    : 'audio/basic',
+      'avi'   : 'video/x-msvideo',
+      'bin'   : 'application/octet-stream',
+      'class' : 'application/octet-stream',
+      'css'   : 'text/css',
+      'csv'   : 'application/vnd.ms-excel',
+      'doc'   : 'application/msword',
+      'dll'   : 'application/octet-stream',
+      'dvi'   : 'application/x-dvi',
+      'exe'   : 'application/octet-stream',
+      'htm'   : 'text/html',
+      'html'  : 'text/html',
+      'json'  : 'application/json',
+      'js'    : 'application/x-javascript',
+      'txt'   : 'text/plain',
+      'bmp'   : 'image/bmp',
+      'rss'   : 'application/rss+xml',
+      'atom'  : 'application/atom+xml',
+      'gif'   : 'image/gif',
+      'jpeg'  : 'image/jpeg',
+      'jpg'   : 'image/jpeg',
+      'jpe'   : 'image/jpeg',
+      'png'   : 'image/png',
+      'ico'   : 'image/vnd.microsoft.icon',
+      'mpeg'  : 'video/mpeg',
+      'mpg'   : 'video/mpeg',
+      'mpe'   : 'video/mpeg',
+      'qt'    : 'video/quicktime',
+      'mov'   : 'video/quicktime',
+      'wmv'   : 'video/x-ms-wmv',
+      'mp2'   : 'audio/mpeg',
+      'mp3'   : 'audio/mpeg',
+      'rm'    : 'audio/x-pn-realaudio',
+      'ram'   : 'audio/x-pn-realaudio',
+      'rpm'   : 'audio/x-pn-realaudio-plugin',
+      'ra'    : 'audio/x-realaudio',
+      'wav'   : 'audio/x-wav',
+      'zip'   : 'application/zip',
+      'pdf'   : 'application/pdf',
+      'xls'   : 'application/vnd.ms-excel',
+      'ppt'   : 'application/vnd.ms-powerpoint',
+      'wbxml' : 'application/vnd.wap.wbxml',
+      'wmlc'  : 'application/vnd.wap.wmlc',
+      'wmlsc' : 'application/vnd.wap.wmlscriptc',
+      'spl'   : 'application/x-futuresplash',
+      'gtar'  : 'application/x-gtar',
+      'gzip'  : 'application/x-gzip',
+      'swf'   : 'application/x-shockwave-flash',
+      'tar'   : 'application/x-tar',
+      'xhtml' : 'application/xhtml+xml',
+      'snd'   : 'audio/basic',
+      'midi'  : 'audio/midi',
+      'mid'   : 'audio/midi',
+      'm3u'   : 'audio/x-mpegurl',
+      'tiff'  : 'image/tiff',
+      'tif'   : 'image/tiff',
+      'rtf'   : 'text/rtf',
+      'wml'   : 'text/vnd.wap.wml',
+      'wmls'  : 'text/vnd.wap.wmlscript',
+      'xsl'   : 'text/xml',
+      'xml'   : 'text/xml',
+      'svg'   : 'image/svg+xml'
+    };
+
+http.createServer(function(request, response) {
+
+    var uri = url.parse(request.url).pathname,
+        filename = path.join(process.cwd(), uri);
+
+    fs.exists(filename, function(exists) {
+        if (exists && fs.statSync(filename).isDirectory()) {
+            filename += `${filename.endsWith('/') ? '' : '/'}index.html`;
+            exists = fs.existsSync(filename);
+        }
+
+        if(!exists) {
+            response.writeHead(404, {"Content-Type": "text/plain"});
+            response.end("404 Not Found");
+            return;
+        }
+
+        fs.readFile(filename, "binary", function(err, file) {
+            if(err) {
+                response.writeHead(500, {"Content-Type": "text/plain"});
+                response.end(err.message);
+                return;
+            }
+
+            var ext = filename.replace(/.*[\.\/\\]/, '').toLowerCase();
+
+            response.writeHead(200, {"Content-Type": (mimeTypes[ext] || "text/plain")});
+            response.end(file, "binary");
+        });
+    });
+
+}).listen(parseInt(port, 10));
+
+console.log("Keyguard running at http://localhost:" + port + "/\nCTRL + C to shutdown");


### PR DESCRIPTION
Add a basic NodeJS script without external dependencies to statically serve the Keyguard files. Adjusted from a public Github gist, added handling of non-existent `*/index.html` files.

Replaces #408.