### PR TITLE
Handle blocked access to local/session storage

### DIFF
--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -230,6 +230,8 @@ export type KeyguardError = {
         CORE: 'Core',
         // used for internal keyguard Errors.
         KEYGUARD: 'Keyguard',
+        // used for errors caused by the browser and its configuration
+        BROWSER: 'Browser',
         // used for the remaining Errors which are not assigned an own type just yet.
         UNCLASSIFIED: 'Unclassified',
     },
@@ -246,5 +248,7 @@ export type KeyguardError = {
         KEY_NOT_FOUND: 'keyId not found',
         // network name does not exist
         INVALID_NETWORK_CONFIG: 'Invalid network config',
+        // when the browser prevents access to LocalStorage or SessionStorage (because of privacy settings)
+        NO_STORAGE_ACCESS: 'Cannot access browser storage because of privacy settings',
     },
 };

--- a/src/components/TabWidthSelector.js
+++ b/src/components/TabWidthSelector.js
@@ -12,7 +12,13 @@ class TabWidthSelector extends Nimiq.Observable {
         this.$el = TabWidthSelector._createElement($el);
 
         // Load last used width from localStorage.
-        this._tabWidth = localStorage.getItem(TabWidthSelector.LOCALSTORAGE_KEY) || TabWidthSelector.DEFAULT_TAB_WIDTH;
+        try {
+            /** @type {string} */
+            this._tabWidth = localStorage.getItem(TabWidthSelector.LOCALSTORAGE_KEY) || '';
+        } catch (error) {
+            // Ignore
+        }
+        this._tabWidth = this._tabWidth || TabWidthSelector.DEFAULT_TAB_WIDTH;
         this._updateClasses();
 
         this.$width2Button = /** @type {HTMLButtonElement} */ (this.$el.querySelector('button[data-width="2"]'));
@@ -67,7 +73,11 @@ class TabWidthSelector extends Nimiq.Observable {
     _updateWidth(width) {
         this._tabWidth = width;
         this._updateClasses();
-        localStorage.setItem(TabWidthSelector.LOCALSTORAGE_KEY, this._tabWidth);
+        try {
+            localStorage.setItem(TabWidthSelector.LOCALSTORAGE_KEY, this._tabWidth);
+        } catch (error) {
+            // Ignore
+        }
         this.fire(TabWidthSelector.Events.INPUT, this._tabWidth);
     }
 

--- a/src/lib/ErrorConstants.js
+++ b/src/lib/ErrorConstants.js
@@ -7,6 +7,8 @@ const ErrorConstants = {
         CORE: 'Core',
         // used for other internal keyguard Errors.
         KEYGUARD: 'Keyguard',
+        // used for errors caused by the browser and its configuration
+        BROWSER: 'Browser',
         // used for the remaining Errors which are not assigned an own type just yet.
         UNCLASSIFIED: 'Unclassified',
     },
@@ -23,6 +25,8 @@ const ErrorConstants = {
         KEY_NOT_FOUND: 'keyId not found',
         // network name does not exist
         INVALID_NETWORK_CONFIG: 'Invalid network config',
+        // when the browser prevents access to LocalStorage or SessionStorage (because of privacy settings)
+        NO_STORAGE_ACCESS: 'Cannot access browser storage because of privacy settings',
     },
 };
 

--- a/src/lib/Errors.js
+++ b/src/lib/Errors.js
@@ -54,6 +54,15 @@ Errors.KeyguardError = class extends Errors.BaseError {
     }
 };
 
+Errors.BrowserError = class extends Errors.BaseError {
+    /**
+     *  @param {string|Error} [messageOrError]
+     */
+    constructor(messageOrError) {
+        super(ErrorConstants.Types.BROWSER, messageOrError);
+    }
+};
+
 Errors.UnclassifiedError = class extends Errors.BaseError {
     /**
      *  @param {string|Error} [messageOrError]

--- a/src/lib/RpcServer.es.js
+++ b/src/lib/RpcServer.es.js
@@ -250,11 +250,15 @@ class RpcServer { // eslint-disable-line no-unused-vars
         // Check for a stored request referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
         if (searchParams.has(UrlRpcEncoder.URL_SEARCHPARAM_NAME)) {
-            const storedRequest = window.sessionStorage.getItem(
-                `request-${searchParams.get(UrlRpcEncoder.URL_SEARCHPARAM_NAME)}`,
-            );
-            if (storedRequest) {
-                return this._receive(JsonUtils.parse(storedRequest), false);
+            try {
+                const storedRequest = window.sessionStorage.getItem(
+                    `request-${searchParams.get(UrlRpcEncoder.URL_SEARCHPARAM_NAME)}`,
+                );
+                if (storedRequest) {
+                    return this._receive(JsonUtils.parse(storedRequest), false);
+                }
+            } catch (error) {
+                // Ignore SessionStorage access error
             }
         }
 
@@ -292,7 +296,11 @@ class RpcServer { // eslint-disable-line no-unused-vars
             console.debug('RpcServer ACCEPT', state.data);
 
             if (persistMessage) {
-                sessionStorage.setItem(`request-${state.data.id}`, JsonUtils.stringify(state.toRequestObject()));
+                try {
+                    sessionStorage.setItem(`request-${state.data.id}`, JsonUtils.stringify(state.toRequestObject()));
+                } catch (error) {
+                    // Ignore SessionStorage access error
+                }
             }
 
             // Call method

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -2,6 +2,7 @@
 /* global ImportFile */
 /* global ImportWords */
 /* global Errors */
+/* global ErrorConstants */
 
 /** @extends {TopLevelApi<KeyguardRequest.ImportRequest>} */
 class ImportApi extends TopLevelApi {
@@ -12,6 +13,13 @@ class ImportApi extends TopLevelApi {
     async parseRequest(request) {
         if (!request) {
             throw new Errors.InvalidRequestError('request is required');
+        }
+
+        try {
+            sessionStorage.setItem('_test', 'write-access');
+            sessionStorage.removeItem('_test');
+        } catch (e) {
+            throw new Errors.BrowserError(ErrorConstants.Messages.NO_STORAGE_ACCESS);
         }
 
         const parsedRequest = {};


### PR DESCRIPTION
This PR enables proper handling of blocked storage access for `localStorage` and `sessionStorage` in browsers with increased privacy settings or some private browsing modes.

Currently the Keyguard throws a `Key not found` error from the iframe, _after_ the user already entered their password.

This PR makes it so the Keyguard simply ignores blocked access to storage if not necessary for the Keyguard to function (TabWidthSelector, RpcServer), but fails with a new `BrowserError` type when it _is_ required, as during import when we want to temporarily store the seed in `sessionStorage` so that we can derive all addresses during discovery in the Hub.