### PR TITLE
QR video scanning

### DIFF
--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -142,7 +142,7 @@ class FileImporter extends Nimiq.Observable {
     async _readQrCode(image) {
         try {
             const qrPosition = LoginFile.calculateQrPosition();
-            return await QrScanner.scanImage(image, qrPosition, null, null, true);
+            return await QrScanner.scanImage(image, qrPosition, undefined, undefined, true, true);
         } catch (e) {
             return null;
         }

--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -9,17 +9,16 @@
 
 class FileImporter extends Nimiq.Observable {
     /**
-     * @param {string | Uint8Array} data
+     * @param {string} str
      * @returns {boolean}
      */
-    static isLoginFileData(data) {
+    static isLoginFileData(str) {
         try {
-            if (typeof data === 'string') {
-                // Make sure it is base64.
-                // This throws an atob() exception if data is not in base64 format.
-                // Skip prefix for PIN-encrypted Login Files.
-                data = Nimiq.BufferUtils.fromBase64(data.substr(0, 2) === '#2' ? data.substr(2) : data);
-            }
+            // Make sure it is base64.
+            // This throws an atob() exception if data is not in base64 format.
+            // Skip prefix for PIN-encrypted Login Files.
+            /** @type {Uint8Array} */
+            const data = Nimiq.BufferUtils.fromBase64(str.substr(0, 2) === '#2' ? str.substr(2) : str);
 
             // Make sure the data size is correct and that a potential label is correctly encoded.
             return data.byteLength === KeyStore.ENCRYPTED_SECRET_SIZE // a secret without label

--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -142,7 +142,7 @@ class FileImporter extends Nimiq.Observable {
     async _readQrCode(image) {
         try {
             const qrPosition = LoginFile.calculateQrPosition();
-            return await QrScanner.scanImage(image, qrPosition, undefined, undefined, undefined, true);
+            return await QrScanner.scanImage(image, qrPosition, undefined, undefined, true);
         } catch (e) {
             return null;
         }

--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -142,7 +142,7 @@ class FileImporter extends Nimiq.Observable {
     async _readQrCode(image) {
         try {
             const qrPosition = LoginFile.calculateQrPosition();
-            return await QrScanner.scanImage(image, qrPosition, undefined, undefined, true, true);
+            return await QrScanner.scanImage(image, qrPosition, undefined, undefined, undefined, true);
         } catch (e) {
             return null;
         }

--- a/src/components/QrVideoScanner.css
+++ b/src/components/QrVideoScanner.css
@@ -13,11 +13,11 @@
     display: block;
 }
 
-.overlay {
+.qr-video-scanner .overlay {
     position: absolute;
 }
 
-.overlay:not(.inactive) {
+.qr-video-scanner:not(.camera-issue) .overlay {
     animation: overlay-animation 400ms infinite alternate ease-in-out;
 }
 
@@ -30,13 +30,13 @@
     }
 }
 
-.overlay svg {
+.qr-video-scanner .overlay svg {
     width: 100%;
     height: 100%;
     stroke: var(--nimiq-gold);
 }
 
-.overlay.inactive svg {
+.qr-video-scanner.camera-issue .overlay svg {
     stroke: rgba(255, 255, 255, .4);
 }
 
@@ -55,7 +55,7 @@
     background: #EFF0F2; /* Indigo 7% */
 }
 
-/* .camera-access-failed {
+.camera-access-failed {
     color: white;
     text-align: center;
     font-size: 2rem;
@@ -71,57 +71,8 @@
     font-weight: bold;
 }
 
-.access-denied-instructions {
-    opacity: .7;
-    position: absolute;
-    left: 50%;
-    bottom: 9rem;
-    width: calc(100% - 4rem);
-    transform: translateX(-50%);
-    line-height: 1.7;
-    white-space: pre-line;
+.qr-video-scanner:not(.camera-issue) .camera-access-failed,
+.qr-video-scanner:not(.no-camera) .no-camera,
+.qr-video-scanner.no-camera .unblock-camera {
+    display: none;
 }
-
-.browser-menu-icon,
-.camera-icon-chrome,
-.camera-icon-firefox {
-    display: inline-block;
-    background-repeat: no-repeat;
-    margin: 0 .2em;
-    position: relative;
-    top: .2em;
-}
-
-.browser-menu-icon {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 3 15"><circle cx="1.5" cy="1.5" r="1.5"/><circle cx="1.5" cy="7.5" r="1.5"/><circle cx="1.5" cy="13.5" r="1.5"/></svg>');
-    height: 1em;
-    width: calc(1em * (3 / 15));
-}
-
-.camera-icon-chrome {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 12"><path fill="%23FF5C48" fill-rule="evenodd" d="M7.8 5h5.4c.4 0 .8.4.8.8v5.4c0 .4-.4.8-.9.8H7.8c-.4 0-.8-.4-.8-.9V5.8c0-.4.4-.8.8-.8zm4.04 4.85c.2-.2.2-.5 0-.7l-.64-.65.65-.65c.2-.2.2-.5 0-.7a.5.5 0 0 0-.7 0l-.66.64-.63-.64a.5.5 0 0 0-.71 0c-.2.2-.2.5 0 .7l.64.65-.64.65c-.2.2-.2.5 0 .7a.48.48 0 0 0 .7 0l.64-.64.65.64a.48.48 0 0 0 .7 0z" clip-rule="evenodd"/><path fill="white" d="M6 5.8C6 4.8 6.8 4 7.8 4H12V.5L9.5 3V.5C9.5.2 9.3 0 9 0H.5C.2 0 0 .2 0 .5v7c0 .3.2.5.5.5H6V5.8z"/></svg>');
-    height: .8em;
-    width: calc(.8em * (14 / 12));
-}
-
-.camera-icon-firefox {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 14 14"><path d="M13.5.3c-.4-.4-.9-.4-1.3 0L9.7 2.8c-.1-.5-.5-.9-1-.9H1c-.6 0-1 .4-1 1v7.7c0 .5.4.9.9 1l-.6.6c-.4.4-.4.9 0 1.3l.6.3c.2 0 .5-.1.6-.3l12-12a1 1 0 0 0 0-1.2zM13.7 11.6V3.5l-4 4.1 4 4zM8.7 11.6c.6 0 1-.4 1-1v-3l-4 4h3z"/></svg>');
-    height: .9em;
-    width: .9em;
-}
-
-.browser-menu-arrow {
-    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 23"><path stroke="%230CA6FE" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 22V3M2 9l7-7 7 7"/></svg>');
-    animation: arrow-bounce 400ms infinite alternate ease-in-out;
-    position: fixed;
-    top: 3rem;
-    right: 2.2rem;
-    width: 2rem;
-    height: calc(2rem / (18 / 23)); calculate from aspect ratio and width
-}
-
-@keyframes arrow-bounce {
-    to {
-        transform: translateY(-1rem);
-    }
-} */

--- a/src/components/QrVideoScanner.css
+++ b/src/components/QrVideoScanner.css
@@ -1,0 +1,127 @@
+.qr-video-scanner {
+    position: relative;
+    overflow: hidden;
+}
+
+.qr-video-scanner video {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.overlay {
+    position: absolute;
+}
+
+.overlay:not(.inactive) {
+    animation: overlay-animation 400ms infinite alternate ease-in-out;
+}
+
+@keyframes overlay-animation {
+    from {
+        transform: scale(.98);
+    }
+    to {
+        transform: scale(1.01);
+    }
+}
+
+.overlay svg {
+    width: 100%;
+    height: 100%;
+    stroke: var(--nimiq-gold);
+}
+
+.overlay.inactive svg {
+    stroke: rgba(255, 255, 255, .4);
+}
+
+.qr-video-scanner .cancel-button {
+    background: white;
+    position: absolute;
+    bottom: 3rem;
+    left: 50%;
+    transform: translateX(-50%);
+    color: var(--nimiq-blue);
+}
+
+.qr-video-scanner .cancel-button:hover,
+.qr-video-scanner .cancel-button:focus,
+.qr-video-scanner .cancel-button:active {
+    background: #EFF0F2; /* Indigo 7% */
+}
+
+/* .camera-access-failed {
+    color: white;
+    text-align: center;
+    font-size: 2rem;
+}
+
+.camera-access-failed-warning {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 30rem;
+    max-width: 80%;
+    font-weight: bold;
+}
+
+.access-denied-instructions {
+    opacity: .7;
+    position: absolute;
+    left: 50%;
+    bottom: 9rem;
+    width: calc(100% - 4rem);
+    transform: translateX(-50%);
+    line-height: 1.7;
+    white-space: pre-line;
+}
+
+.browser-menu-icon,
+.camera-icon-chrome,
+.camera-icon-firefox {
+    display: inline-block;
+    background-repeat: no-repeat;
+    margin: 0 .2em;
+    position: relative;
+    top: .2em;
+}
+
+.browser-menu-icon {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 3 15"><circle cx="1.5" cy="1.5" r="1.5"/><circle cx="1.5" cy="7.5" r="1.5"/><circle cx="1.5" cy="13.5" r="1.5"/></svg>');
+    height: 1em;
+    width: calc(1em * (3 / 15));
+}
+
+.camera-icon-chrome {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 12"><path fill="%23FF5C48" fill-rule="evenodd" d="M7.8 5h5.4c.4 0 .8.4.8.8v5.4c0 .4-.4.8-.9.8H7.8c-.4 0-.8-.4-.8-.9V5.8c0-.4.4-.8.8-.8zm4.04 4.85c.2-.2.2-.5 0-.7l-.64-.65.65-.65c.2-.2.2-.5 0-.7a.5.5 0 0 0-.7 0l-.66.64-.63-.64a.5.5 0 0 0-.71 0c-.2.2-.2.5 0 .7l.64.65-.64.65c-.2.2-.2.5 0 .7a.48.48 0 0 0 .7 0l.64-.64.65.64a.48.48 0 0 0 .7 0z" clip-rule="evenodd"/><path fill="white" d="M6 5.8C6 4.8 6.8 4 7.8 4H12V.5L9.5 3V.5C9.5.2 9.3 0 9 0H.5C.2 0 0 .2 0 .5v7c0 .3.2.5.5.5H6V5.8z"/></svg>');
+    height: .8em;
+    width: calc(.8em * (14 / 12));
+}
+
+.camera-icon-firefox {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 14 14"><path d="M13.5.3c-.4-.4-.9-.4-1.3 0L9.7 2.8c-.1-.5-.5-.9-1-.9H1c-.6 0-1 .4-1 1v7.7c0 .5.4.9.9 1l-.6.6c-.4.4-.4.9 0 1.3l.6.3c.2 0 .5-.1.6-.3l12-12a1 1 0 0 0 0-1.2zM13.7 11.6V3.5l-4 4.1 4 4zM8.7 11.6c.6 0 1-.4 1-1v-3l-4 4h3z"/></svg>');
+    height: .9em;
+    width: .9em;
+}
+
+.browser-menu-arrow {
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 23"><path stroke="%230CA6FE" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 22V3M2 9l7-7 7 7"/></svg>');
+    animation: arrow-bounce 400ms infinite alternate ease-in-out;
+    position: fixed;
+    top: 3rem;
+    right: 2.2rem;
+    width: 2rem;
+    height: calc(2rem / (18 / 23)); calculate from aspect ratio and width
+}
+
+@keyframes arrow-bounce {
+    to {
+        transform: translateY(-1rem);
+    }
+} */

--- a/src/components/QrVideoScanner.css
+++ b/src/components/QrVideoScanner.css
@@ -47,6 +47,7 @@
     left: 50%;
     transform: translateX(-50%);
     color: var(--nimiq-blue);
+    -webkit-tap-highlight-color: transparent;
 }
 
 .qr-video-scanner .cancel-button:hover,

--- a/src/components/QrVideoScanner.js
+++ b/src/components/QrVideoScanner.js
@@ -1,0 +1,140 @@
+/* global Nimiq */
+/* global I18n */
+/* global QrScanner */
+/* global TemplateTags */
+
+class QrVideoScanner extends Nimiq.Observable {
+    /**
+     * @param {HTMLDivElement} [$el]
+     */
+    constructor($el) {
+        super();
+
+        this._isRepositioningOverlay = false;
+
+        this.$el = QrVideoScanner._createElement($el);
+
+        /** @type {HTMLVideoElement} */
+        const $video = (this.$el.querySelector('video'));
+
+        /** @type {HTMLDivElement} */
+        this.$overlay = (this.$el.querySelector('.overlay'));
+
+        /** @type {HTMLButtonElement} */
+        const $cancelButton = (this.$el.querySelector('.cancel-button'));
+
+        // this.$el.addEventListener('click', () => this.copy());
+        this._scanner = new QrScanner($video, result => this._onResult(result));
+
+        $cancelButton.addEventListener('click', () => this.fire(QrVideoScanner.Events.CANCEL));
+    }
+
+    async start() {
+        try {
+            await this._scanner.start();
+            // this.cameraAccessFailed = false;
+            // if (this._cameraRetryTimer) {
+            //     window.clearInterval(this._cameraRetryTimer);
+            //     this._cameraRetryTimer = null;
+            // }
+        } catch (error) {
+            // this.cameraAccessFailed = true;
+            this.fire(QrVideoScanner.Events.ERROR, typeof error === 'string' ? new Error(error) : error);
+            // if (!this._cameraRetryTimer) {
+            //     this._cameraRetryTimer = window.setInterval(() => this.start(), 3000);
+            // }
+        }
+        // return !this.cameraAccessFailed;
+    }
+
+    /**
+     * @param {string} result
+     */
+    _onResult(result) {
+        // if ((result === this._lastResult && Date.now() - this._lastResultTime < this.reportFrequency)
+        //     || (this.validate && !this.validate(result))) return;
+        // this._lastResult = result;
+        // this._lastResultTime = Date.now();
+        this.fire(QrVideoScanner.Events.RESULT, result);
+    }
+
+    stop() {
+        this._scanner.stop();
+        // if (this._cameraRetryTimer) {
+        //     window.clearInterval(this._cameraRetryTimer);
+        //     this._cameraRetryTimer = null;
+        // }
+    }
+
+    repositionOverlay() {
+        if (this._isRepositioningOverlay) return;
+        this._isRepositioningOverlay = true;
+        requestAnimationFrame(() => {
+            const scannerHeight = this.$el.offsetHeight;
+            const scannerWidth = this.$el.offsetWidth;
+
+            const shorterSideLength = Math.min(scannerHeight, scannerWidth);
+            if (!shorterSideLength) return; // component not visible or destroyed
+
+            // not always the accurate size of the sourceRect for QR detection in QrScannerLib (e.g. if video is
+            // landscape and screen portrait) but looks nicer in the UI.
+            const overlaySize = Math.ceil(2 / 3 * shorterSideLength);
+
+            this.$overlay.style.width = `${overlaySize}px`;
+            this.$overlay.style.height = `${overlaySize}px`;
+            this.$overlay.style.top = `${(scannerHeight - overlaySize) / 2}px`;
+            this.$overlay.style.left = `${(scannerWidth - overlaySize) / 2}px`;
+
+            this._isRepositioningOverlay = false;
+        });
+    }
+
+    // copy() {
+    //     ClipboardUtils.copy(this._text);
+
+    //     window.clearTimeout(this._copiedResetTimeout);
+    //     this.$el.classList.add('copied', 'show-tooltip');
+    //     this._copiedResetTimeout = window.setTimeout(
+    //         () => this.$el.classList.remove('copied', 'show-tooltip'),
+    //         QrVideoScanner.DISPLAY_TIME,
+    //     );
+    // }
+
+    /**
+     * @returns {HTMLDivElement}
+     */
+    getElement() {
+        return this.$el;
+    }
+
+    /**
+     * @param {HTMLDivElement} [$el]
+     * @returns {HTMLDivElement}
+     */
+    static _createElement($el) {
+        const $element = $el || document.createElement('div');
+        $element.classList.add('qr-video-scanner', 'nq-blue-bg');
+
+        /* eslint-disable max-len */
+        $element.innerHTML = TemplateTags.noVars`
+            <video muted autoplay playsinline width="600" height="600"></video>
+            <div class="overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 238 238">
+                    <path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M31.3 2H10a8 8 0 0 0-8 8v21.3M206.8 2H228a8 8 0 0 1 8 8v21.3m0 175.4V228a8 8 0 0 1-8 8h-21.3m-175.4 0H10a8 8 0 0 1-8-8v-21.3"/>
+                </svg>
+            </div>
+            <button class="nq-button-s inverse cancel-button" data-i18n="qr-video-scanner-cancel">Cancel</button>
+        `;
+        /* eslint-enable max-len */
+
+        I18n.translateDom($element);
+
+        return $element;
+    }
+}
+
+QrVideoScanner.Events = {
+    RESULT: 'qr-video-scanner-result',
+    ERROR: 'qr-video-scanner-error',
+    CANCEL: 'qr-video-scanner-cancel',
+};

--- a/src/components/QrVideoScanner.js
+++ b/src/components/QrVideoScanner.js
@@ -7,10 +7,10 @@ class QrVideoScanner extends Nimiq.Observable {
     // eslint-disable-next-line valid-jsdoc
     /**
      * @param {HTMLDivElement} [$el]
-     * @param {number} [reportFrequency = 7000]
      * @param {(result: string) => boolean} [validator]
+     * @param {number} [reportFrequency = 7000]
      */
-    constructor($el, reportFrequency = 7000, validator = /** @param {string} result */ result => !!result) {
+    constructor($el, validator = /** @param {string} result */ result => !!result, reportFrequency = 7000) {
         super();
 
         this._reportFrequency = reportFrequency;

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -14,7 +14,7 @@
 
 class QrScanner {
     static async hasCamera() {
-        if (!navigator.mediaDevices) return Promise.resolve(false);
+        if (!navigator.mediaDevices) return false;
         // note that enumerateDevices can always be called and does not prompt the user for permission. However, device
         // labels are only readable if served via https and an active media stream exists or permanent permission is
         // given. That doesn't matter for us though as we don't require labels.

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -383,7 +383,14 @@ class QrScanner {
             /** @type {string | undefined} */
             let result;
             try {
-                result = await QrScanner.scanImage(this.$video, this._scanRegion, this._qrEnginePromise, this.$canvas);
+                result = await QrScanner.scanImage(
+                    this.$video,
+                    this._scanRegion,
+                    this._qrEnginePromise,
+                    this.$canvas,
+                    /* fixedCanvasSize */ true,
+                    /* alsoTryWitoutScanRegion */ false,
+                );
             } catch (error) {
                 if (!this._active) return;
                 const errorMessage = error.message || error;

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -212,7 +212,7 @@ class QrScanner {
     /**
      * @param {HTMLImageElement | HTMLVideoElement | string} imageOrFileOrUrl
      * @param {RectArea} [scanRegion]
-     * @param {Promise<Worker>} [givenEngine] // TODO: Or BarcodeDecoder
+     * @param {Promise<Worker>} [givenEngine] // TODO: Or BarcodeDetector
      * @param {HTMLCanvasElement} [givenCanvas]
      * @param {boolean} [fixedCanvasSize = false]
      * @param {boolean} [alsoTryWithoutScanRegion = false]
@@ -280,7 +280,7 @@ class QrScanner {
                 });
             }
             return new Promise((resolve, reject) => {
-                /** @type {any} */ // TODO: BarcodeDecoder
+                /** @type {any} */ // TODO: BarcodeDetector
                 const decoder = engine;
 
                 const timeout = window.setTimeout(() => reject('Scanner error: timeout'), 10000);
@@ -321,7 +321,7 @@ class QrScanner {
     /**
      *
      * @param {string} [workerPath]
-     * @returns {Promise<Worker>} // TODO: Or BarcodeDecoder
+     * @returns {Promise<Worker>} // TODO: Or BarcodeDetector
      */
     static async createQrEngine(workerPath = QrScanner.WORKER_PATH) {
         // @ts-ignore Cannot find name 'BarcodeDetector'

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -105,8 +105,8 @@ class QrScanner {
         }
 
         try {
-            // @ts-ignore Cannot find name 'ImageCapture'
-            const imageCapture = new ImageCapture(track);
+            // @ts-ignore Property 'ImageCapture' does not exist on type 'Window & typeof globalThis'
+            const imageCapture = new window.ImageCapture(track);
             const result = await imageCapture.getPhotoCapabilities();
             return result.fillLightMode.includes('flash');
         } catch (error) {
@@ -282,16 +282,17 @@ class QrScanner {
             return new Promise((resolve, reject) => {
                 /** @type {any} */ // TODO: BarcodeDetector
                 const decoder = engine;
-
                 const timeout = window.setTimeout(() => reject('Scanner error: timeout'), 10000);
+
                 /** @param {string[]} scanResults */
-                decoder.detect(canvas).then(/** @param {{rawValue: string}[]} scanResults */ scanResults => {
-                    if (!scanResults.length) {
-                        reject(QrScanner.NO_QR_CODE_FOUND);
-                    } else {
-                        resolve(scanResults[0].rawValue);
-                    }
-                })
+                decoder.detect(canvas)
+                    .then(/** @param {{rawValue: string}[]} scanResults */ scanResults => {
+                        if (!scanResults.length) {
+                            reject(QrScanner.NO_QR_CODE_FOUND);
+                        } else {
+                            resolve(scanResults[0].rawValue);
+                        }
+                    })
                     .catch(/** @param {string | Error} e */ e => {
                         reject(`Scanner error: ${e instanceof Error ? e.message : e}`);
                     })
@@ -319,7 +320,6 @@ class QrScanner {
     }
 
     /**
-     *
      * @param {string} [workerPath]
      * @returns {Promise<Worker>} // TODO: Or BarcodeDetector
      */
@@ -447,7 +447,6 @@ class QrScanner {
     }
 
     /**
-     *
      * @param {MediaTrackConstraints[]} constraintsToTry
      * @returns {Promise<MediaStream>}
      */

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -1,134 +1,550 @@
 /* eslint-disable prefer-promise-reject-errors, no-throw-literal */
+/* global BarcodeDetector */
+
+/**
+ * @typedef {{
+ *     x?: number,
+ *     y?: number,
+ *     width?: number,
+ *     height?: number,
+ *     downScaledWidth?: number,
+ *     downScaledHeight?: number,
+ * }} RectArea
+ */
 
 class QrScanner {
+    static async hasCamera() {
+        if (!navigator.mediaDevices) return Promise.resolve(false);
+        // note that enumerateDevices can always be called and does not prompt the user for permission. However, device
+        // labels are only readable if served via https and an active media stream exists or permanent permission is
+        // given. That doesn't matter for us though as we don't require labels.
+        try {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            return devices.some(device => device.kind === 'videoinput');
+        } catch (error) {
+            return false;
+        }
+    }
+
+    // eslint-disable-next-line valid-jsdoc
     /**
-     * @param {HTMLImageElement | string} imageOrUrl
-     * @param {object?} sourceRect
-     * @param {Worker?} givenWorker
-     * @param {HTMLCanvasElement?} canvas
-     * @param {boolean} [alsoTryWithoutSourceRect]
+     * @param {HTMLVideoElement} video
+     * @param {(result: string) => any} onDecode
+     * @param {number | ((error: string) => any)} [canvasSizeOrOnDecodeError]
+     * @param {number | ((video: HTMLVideoElement) => RectArea)} [canvasSizeOrCalculateScanRegion]
+     * @param {'environment' | 'user'} [preferredFacingMode = 'environment']
+     */
+    constructor(
+        video,
+        onDecode,
+        canvasSizeOrOnDecodeError,
+        canvasSizeOrCalculateScanRegion,
+        preferredFacingMode = 'environment',
+    ) {
+        this.$video = video;
+        this.$canvas = document.createElement('canvas');
+        this._onDecode = onDecode;
+        this._legacyCanvasSize = QrScanner.DEFAULT_CANVAS_SIZE;
+        this._preferredFacingMode = preferredFacingMode;
+        this._active = false;
+        this._paused = false;
+        this._flashOn = false;
+
+        if (typeof canvasSizeOrOnDecodeError === 'number') {
+            // legacy function signature where the third argument is the canvas size
+            this._legacyCanvasSize = canvasSizeOrOnDecodeError;
+            console.warn('You\'re using a deprecated version of the QrScanner constructor which will be removed in '
+                + 'the future');
+        } else if (canvasSizeOrOnDecodeError) {
+            this._onDecodeError = canvasSizeOrOnDecodeError;
+        }
+
+        if (typeof canvasSizeOrCalculateScanRegion === 'number') {
+            // legacy function signature where the fourth argument is the canvas size
+            this._legacyCanvasSize = canvasSizeOrCalculateScanRegion;
+            console.warn('You\'re using a deprecated version of the QrScanner constructor which will be removed in '
+                + 'the future');
+        } else if (canvasSizeOrCalculateScanRegion) {
+            this._calculateScanRegion = canvasSizeOrCalculateScanRegion;
+        }
+
+        this._scanRegion = this._calculateScanRegion(video);
+
+        this._onPlay = this._onPlay.bind(this);
+        this._onLoadedMetaData = this._onLoadedMetaData.bind(this);
+        this._onVisibilityChange = this._onVisibilityChange.bind(this);
+
+        // Allow inline playback on iPhone instead of requiring full screen playback,
+        // see https://webkit.org/blog/6784/new-video-policies-for-ios/
+        // @ts-ignore Property 'playsInline' does not exist on type 'HTMLVideoElement'
+        this.$video.playsInline = true;
+        // Allow play() on iPhone without requiring a user gesture. Should not really be needed as camera stream
+        // includes no audio, but just to be safe.
+        this.$video.muted = true;
+        // @ts-ignore Property 'disablePictureInPicture' does not exist on type 'HTMLVideoElement'
+        this.$video.disablePictureInPicture = true;
+        this.$video.addEventListener('play', this._onPlay);
+        this.$video.addEventListener('loadedmetadata', this._onLoadedMetaData);
+        document.addEventListener('visibilitychange', this._onVisibilityChange);
+
+        this._qrEnginePromise = QrScanner.createQrEngine();
+    }
+
+    /**
+     * @returns {Promise<boolean>}
+     */
+    async hasFlash() {
+        if (!('ImageCapture' in window)) return false;
+
+        const track = this.$video.srcObject && this.$video.srcObject instanceof MediaStream
+            ? this.$video.srcObject.getVideoTracks()[0]
+            : null;
+
+        if (!track) {
+            throw 'Camera not started or not available';
+        }
+
+        try {
+            // @ts-ignore Cannot find name 'ImageCapture'
+            const imageCapture = new ImageCapture(track);
+            const result = await imageCapture.getPhotoCapabilities();
+            return result.fillLightMode.includes('flash');
+        } catch (error) {
+            console.warn(error);
+            return false;
+        }
+    }
+
+    isFlashOn() {
+        return this._flashOn;
+    }
+
+    async toggleFlash() {
+        return this._setFlash(!this._flashOn);
+    }
+
+    async turnFlashOff() {
+        return this._setFlash(false);
+    }
+
+    async turnFlashOn() {
+        return this._setFlash(true);
+    }
+
+    destroy() {
+        this.$video.removeEventListener('loadedmetadata', this._onLoadedMetaData);
+        this.$video.removeEventListener('play', this._onPlay);
+        document.removeEventListener('visibilitychange', this._onVisibilityChange);
+
+        this.stop();
+        QrScanner._postWorkerMessage(this._qrEnginePromise, 'close');
+    }
+
+    async start() {
+        if (this._active && !this._paused) return;
+
+        if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost') {
+            // warn but try starting the camera anyways
+            console.warn('The camera stream is only accessible if the page is transferred via https.');
+        }
+        this._active = true;
+        this._paused = false;
+        if (document.hidden) return; // camera will be started as soon as tab is in foreground
+
+        window.clearTimeout(this._offTimeout);
+        this._offTimeout = undefined;
+        if (this.$video.srcObject) {
+            // camera stream already/still set
+            this.$video.play();
+            return;
+        }
+
+        try {
+            let facingMode = this._preferredFacingMode;
+            /** @type {MediaStream} */
+            let stream;
+            try {
+                stream = await this._getCameraStream(facingMode, true);
+            } catch (error) {
+                // We (probably) don't have a camera of the requested facing mode
+                facingMode = facingMode === 'environment' ? 'user' : 'environment';
+                stream = await this._getCameraStream(); // throws if camera is not accessible (e.g. due to not https)
+            }
+
+            // Try to determine the facing mode from the stream, otherwise use our guess. Note that the guess is not
+            // always accurate as Safari returns cameras of different facing mode, even for exact constraints.
+            facingMode = this._getFacingMode(stream) || facingMode;
+            this.$video.srcObject = stream;
+            this.$video.play();
+            this._setVideoMirror(facingMode);
+        } catch (error) {
+            this._active = false;
+            throw error;
+        }
+    }
+
+    stop() {
+        this.pause();
+        this._active = false;
+    }
+
+    pause() {
+        this._paused = true;
+        if (!this._active) {
+            return;
+        }
+        this.$video.pause();
+        if (this._offTimeout) {
+            return;
+        }
+        this._offTimeout = window.setTimeout(() => {
+            const tracks = this.$video.srcObject && this.$video.srcObject instanceof MediaStream
+                ? this.$video.srcObject.getTracks()
+                : [];
+            for (const track of tracks) {
+                track.stop(); //  note that this will also automatically turn the flashlight off
+            }
+            this.$video.srcObject = null;
+            this._offTimeout = undefined;
+        }, 300);
+    }
+
+    /**
+     * @param {HTMLImageElement | HTMLVideoElement | string} imageOrFileOrUrl
+     * @param {RectArea} [scanRegion]
+     * @param {Promise<Worker>} [givenEngine] // TODO: Or BarcodeDecoder
+     * @param {HTMLCanvasElement} [givenCanvas]
+     * @param {boolean} [fixedCanvasSize = false]
+     * @param {boolean} [alsoTryWithoutScanRegion = false]
      * @returns {Promise<string>}
      */
-    static async scanImage(imageOrUrl, sourceRect = null, givenWorker = null, canvas = null,
-        alsoTryWithoutSourceRect = false) {
-        let createdNewWorker = false;
-        /** @type {Worker} */
-        let worker;
-        if (!givenWorker) {
-            worker = new Worker(QrScanner.WORKER_PATH);
-            createdNewWorker = true;
-        } else {
-            worker = givenWorker;
-        }
-        try {
-            return await new Promise((resolve, reject) => {
-                /** @type {number | undefined} */
-                let timeout;
-                /** @type {(e: ErrorEvent | Error | string) => any} */
-                let onError;
-                /**
-                 * @param {Event} event
-                 */
-                const onMessage = event => {
-                    // @ts-ignore
-                    if (event.data.type !== 'qrResult') {
-                        return;
-                    }
-                    worker.removeEventListener('message', onMessage);
-                    worker.removeEventListener('error', onError);
-                    window.clearTimeout(timeout);
-                    // @ts-ignore
-                    if (event.data.data !== null) {
-                        // @ts-ignore
-                        resolve(event.data.data);
-                    } else {
-                        reject('QR code not found.');
-                    }
-                };
-                /**
-                 * @param {ErrorEvent | Error | string} e
-                 */
-                onError = e => {
-                    worker.removeEventListener('message', onMessage);
-                    worker.removeEventListener('error', onError);
-                    window.clearTimeout(timeout);
-                    // eslint-disable-next-line no-nested-ternary
-                    const errorMessage = !e
-                        ? 'Unknown Error'
-                        : typeof e === 'string' ? e : e.message;
-                    reject(`Scanner error: ${errorMessage}`);
-                };
-                worker.addEventListener('message', onMessage);
-                worker.addEventListener('error', onError);
-                timeout = window.setTimeout(() => onError('timeout'), 3000);
-                QrScanner._loadImage(imageOrUrl).then(image => {
-                    const imageData = QrScanner._getImageData(image, sourceRect, canvas);
-                    worker.postMessage({
+    static scanImage(
+        imageOrFileOrUrl,
+        scanRegion,
+        givenEngine,
+        givenCanvas,
+        fixedCanvasSize = false,
+        alsoTryWithoutScanRegion = false,
+    ) {
+        const qrEngine = givenEngine || QrScanner.createQrEngine();
+
+        let promise = Promise.all([
+            qrEngine,
+            QrScanner._loadImage(imageOrFileOrUrl),
+        ]).then(([engine, image]) => {
+            const [canvas, canvasContext] = this._drawToCanvas(image, scanRegion, givenCanvas, fixedCanvasSize);
+
+            if (engine instanceof Worker) {
+                return new Promise((resolve, reject) => {
+                    /** @type {(error: string | ErrorEvent) => any} */
+                    let onError;
+
+                    /** @type {number} */
+                    let timeout;
+
+                    /** @param {MessageEvent} event */
+                    const onMessage = event => {
+                        if (event.data.type !== 'qrResult') {
+                            return;
+                        }
+                        engine.removeEventListener('message', onMessage);
+                        engine.removeEventListener('error', onError);
+                        window.clearTimeout(timeout);
+                        if (event.data.data !== null) {
+                            resolve(event.data.data);
+                        } else {
+                            reject(QrScanner.NO_QR_CODE_FOUND);
+                        }
+                    };
+
+                    /** @param {string | ErrorEvent} e */
+                    onError = e => {
+                        engine.removeEventListener('message', onMessage);
+                        engine.removeEventListener('error', onError);
+                        window.clearTimeout(timeout);
+                        const errorMessage = !e // eslint-disable-line no-nested-ternary
+                            ? 'Unknown Error'
+                            : (e instanceof Error ? e.message : e);
+                        reject(`Scanner error: ${errorMessage}`);
+                    };
+
+                    engine.addEventListener('message', onMessage);
+                    engine.addEventListener('error', onError);
+                    timeout = window.setTimeout(() => onError('timeout'), 10000);
+
+                    const imageData = canvasContext.getImageData(0, 0, canvas.width, canvas.height);
+                    engine.postMessage({
                         type: 'decode',
                         data: imageData,
                     }, [imageData.data.buffer]);
-                }).catch(onError);
-            });
-        } catch (e) {
-            if (sourceRect && alsoTryWithoutSourceRect) {
-                return await QrScanner.scanImage(imageOrUrl, null, worker, canvas);
+                });
             }
-            throw e;
-        } finally {
-            if (createdNewWorker) {
-                worker.postMessage({
-                    type: 'close',
+            return new Promise((resolve, reject) => {
+                /** @type {any} */ // TODO: BarcodeDecoder
+                const decoder = engine;
+
+                const timeout = window.setTimeout(() => reject('Scanner error: timeout'), 10000);
+                /** @param {string[]} scanResults */
+                decoder.detect(canvas).then(/** @param {{rawValue: string}[]} scanResults */ scanResults => {
+                    if (!scanResults.length) {
+                        reject(QrScanner.NO_QR_CODE_FOUND);
+                    } else {
+                        resolve(scanResults[0].rawValue);
+                    }
+                })
+                    .catch(/** @param {string | Error} e */ e => {
+                        reject(`Scanner error: ${e instanceof Error ? e.message : e}`);
+                    })
+                    .finally(() => window.clearTimeout(timeout));
+            });
+        });
+
+        if (scanRegion && alsoTryWithoutScanRegion) {
+            promise = promise.catch(() => QrScanner.scanImage(
+                imageOrFileOrUrl,
+                undefined,
+                givenEngine,
+                givenCanvas,
+                fixedCanvasSize,
+                false,
+            ));
+        }
+
+        promise = promise.finally(async () => {
+            if (givenEngine) return;
+            QrScanner._postWorkerMessage(qrEngine, 'close').catch(() => {});
+        });
+
+        return promise;
+    }
+
+    /**
+     *
+     * @param {string} [workerPath]
+     * @returns {Promise<Worker>} // TODO: Or BarcodeDecoder
+     */
+    static async createQrEngine(workerPath = QrScanner.WORKER_PATH) {
+        // @ts-ignore Cannot find name 'BarcodeDetector'
+        if ('BarcodeDetector' in window && (await BarcodeDetector.getSupportedFormats()).includes('qr_code')) {
+            // @ts-ignore Cannot find name 'BarcodeDetector'
+            return new BarcodeDetector({ formats: ['qr_code'] });
+        }
+
+        return new Worker(workerPath);
+    }
+
+    _onPlay() {
+        this._scanRegion = this._calculateScanRegion(this.$video);
+        this._scanFrame();
+    }
+
+    _onLoadedMetaData() {
+        this._scanRegion = this._calculateScanRegion(this.$video);
+    }
+
+    _onVisibilityChange() {
+        if (document.hidden) {
+            this.pause();
+        } else if (this._active) {
+            this.start();
+        }
+    }
+
+    /**
+     * @param {HTMLVideoElement} video
+     * @returns {RectArea}
+     */
+    _calculateScanRegion(video) {
+        // Default scan region calculation. Note that this can be overwritten in the constructor.
+        const smallestDimension = Math.min(video.videoWidth, video.videoHeight);
+        const scanRegionSize = Math.round(2 / 3 * smallestDimension);
+        return {
+            x: (video.videoWidth - scanRegionSize) / 2,
+            y: (video.videoHeight - scanRegionSize) / 2,
+            width: scanRegionSize,
+            height: scanRegionSize,
+            downScaledWidth: this._legacyCanvasSize,
+            downScaledHeight: this._legacyCanvasSize,
+        };
+    }
+
+    _scanFrame() {
+        if (!this._active || this.$video.paused || this.$video.ended) return;
+        // using requestAnimationFrame to avoid scanning if tab is in background
+        requestAnimationFrame(async () => {
+            if (this.$video.readyState <= 1) {
+                // Skip scans until the video is ready as drawImage() only works correctly on a video with readyState
+                // > 1, see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage#Notes.
+                // This also avoids false positives for videos paused after a successful scan which remains visible on
+                // the canvas until the video is started again and ready.
+                this._scanFrame();
+                return;
+            }
+            /** @type {string | undefined} */
+            let result;
+            try {
+                result = await QrScanner.scanImage(this.$video, this._scanRegion, this._qrEnginePromise, this.$canvas);
+            } catch (error) {
+                if (!this._active) return;
+                const errorMessage = error.message || error;
+                if (errorMessage.includes('service unavailable')) {
+                    // When the native BarcodeDetector crashed, create a new one
+                    this._qrEnginePromise = QrScanner.createQrEngine();
+                }
+                this._onDecodeError(error);
+            }
+
+            if (result) {
+                this._onDecode(result);
+            }
+
+            this._scanFrame();
+        });
+    }
+
+    /**
+     * @param {string} error
+     */
+    _onDecodeError(error) {
+        // default error handler; can be overwritten in the constructor
+        if (error === QrScanner.NO_QR_CODE_FOUND) return;
+        console.log(error);
+    }
+
+    /**
+     * @param {'environment' | 'user'} [facingMode]
+     * @param {boolean} [exact = false]
+     * @returns {Promise<MediaStream>}
+     */
+    _getCameraStream(facingMode, exact = false) {
+        /** @type {MediaTrackConstraints[]} */
+        const constraintsToTry = [{
+            width: { min: 1024 },
+        }, {
+            width: { min: 768 },
+        }, {}];
+
+        if (facingMode) {
+            if (exact) {
+                const exactFacingMode = { exact: facingMode };
+                constraintsToTry.forEach(constraint => {
+                    constraint.facingMode = exactFacingMode;
+                });
+            } else {
+                constraintsToTry.forEach(constraint => {
+                    constraint.facingMode = facingMode;
                 });
             }
         }
+        return this._getMatchingCameraStream(constraintsToTry);
     }
 
+    /**
+     *
+     * @param {MediaTrackConstraints[]} constraintsToTry
+     * @returns {Promise<MediaStream>}
+     */
+    _getMatchingCameraStream(constraintsToTry) {
+        if (!navigator.mediaDevices || constraintsToTry.length === 0) {
+            return Promise.reject('Camera not found.');
+        }
+        return navigator.mediaDevices.getUserMedia({
+            video: constraintsToTry.shift(),
+        }).catch(() => this._getMatchingCameraStream(constraintsToTry));
+    }
 
     /**
-     * @param {HTMLImageElement} image
-     * @param {object?} sourceRect
-     * @param {HTMLCanvasElement?} canvas
-     * @returns {ImageData}
+     * @param {boolean} on
+     * @returns {Promise<void>}
      */
-    static _getImageData(image, sourceRect = null, canvas = null) {
+    async _setFlash(on) {
+        const hasFlash = await this.hasFlash();
+
+        if (!hasFlash) throw 'No flash available';
+
+        // Note that the video track is guaranteed to exist at this point
+        await /** @type {MediaStream} */ (this.$video.srcObject).getVideoTracks()[0].applyConstraints({
+            // @ts-ignore Type '{ torch: boolean; }' is not assignable to type 'MediaTrackConstraintSet'
+            advanced: [{ torch: on }],
+        });
+
+        this._flashOn = on;
+    }
+
+    /**
+     * @param {'environment' | 'user'} facingMode
+     */
+    _setVideoMirror(facingMode) {
+        // in user facing mode mirror the video to make it easier for the user to position the QR code
+        const scaleFactor = facingMode === 'user' ? -1 : 1;
+        this.$video.style.transform = `scaleX(${scaleFactor})`;
+    }
+
+    /**
+     * @param {MediaStream} videoStream
+     * @returns {'environment' | 'user' | null}
+     */
+    _getFacingMode(videoStream) {
+        const videoTrack = videoStream.getVideoTracks()[0];
+        if (!videoTrack) return null; // unknown
+        // inspired by https://github.com/JodusNodus/react-qr-reader/blob/master/src/getDeviceId.js#L13
+        if (/rear|back|environment/i.test(videoTrack.label)) return 'environment';
+        if (/front|user|face/i.test(videoTrack.label)) return 'user';
+        return null; // unknown
+    }
+
+    /**
+     * @param {HTMLImageElement | HTMLVideoElement} image
+     * @param {RectArea?} scanRegion
+     * @param {HTMLCanvasElement?} canvas
+     * @param {boolean} [fixedCanvasSize = false]
+     * @returns {[HTMLCanvasElement, CanvasRenderingContext2D]}
+     */
+    static _drawToCanvas(image, scanRegion = null, canvas = null, fixedCanvasSize = false) {
         canvas = canvas || document.createElement('canvas');
-        const sourceRectX = sourceRect && sourceRect.x ? sourceRect.x : 0;
-        const sourceRectY = sourceRect && sourceRect.y ? sourceRect.y : 0;
-        // @ts-ignore
-        const sourceRectWidth = sourceRect && sourceRect.width ? sourceRect.width : image.width;
-        const sourceRectHeight = sourceRect && sourceRect.height ? sourceRect.height : image.height;
-        if (canvas.width !== sourceRectWidth || canvas.height !== sourceRectHeight) {
-            canvas.width = sourceRectWidth;
-            canvas.height = sourceRectHeight;
+        const scanRegionX = scanRegion && scanRegion.x ? scanRegion.x : 0;
+        const scanRegionY = scanRegion && scanRegion.y ? scanRegion.y : 0;
+        const scanRegionWidth = scanRegion && scanRegion.width
+            ? scanRegion.width
+            : image.width || /** @type {HTMLVideoElement} */ (image).videoWidth;
+        const scanRegionHeight = scanRegion && scanRegion.height
+            ? scanRegion.height
+            : image.height || /** @type {HTMLVideoElement} */ (image).videoHeight;
+        if (!fixedCanvasSize) {
+            canvas.width = scanRegion && scanRegion.downScaledWidth
+                ? scanRegion.downScaledWidth
+                : scanRegionWidth;
+            canvas.height = scanRegion && scanRegion.downScaledHeight
+                ? scanRegion.downScaledHeight
+                : scanRegionHeight;
         }
         const context = canvas.getContext('2d', { alpha: false });
-        if (!context) throw ('Cannot get canvas 2D context');
+        if (!context) throw 'Unable to get canvas context';
         context.imageSmoothingEnabled = false; // gives less blurry images
         context.drawImage(
             image,
-            sourceRectX,
-            sourceRectY,
-            sourceRectWidth,
-            sourceRectHeight,
-            0,
-            0,
-            canvas.width,
-            canvas.height,
+            scanRegionX, scanRegionY, scanRegionWidth, scanRegionHeight,
+            0, 0, canvas.width, canvas.height,
         );
-        return context.getImageData(0, 0, canvas.width, canvas.height);
+        return [canvas, context];
     }
 
     /**
-     * @param {HTMLImageElement | string} imageOrUrl
-     * @returns {Promise<HTMLImageElement>}
+     * @param {HTMLImageElement | HTMLVideoElement | string} imageOrVideoOrUrl
+     * @returns {Promise<HTMLImageElement | HTMLVideoElement>}
      */
-    static async _loadImage(imageOrUrl) {
+    static async _loadImage(imageOrVideoOrUrl) {
+        if (imageOrVideoOrUrl instanceof HTMLVideoElement) {
+            return imageOrVideoOrUrl;
+        }
+
+        /** @type {HTMLImageElement} */
         let image;
-        if (imageOrUrl instanceof Image) {
-            image = imageOrUrl;
+        if (imageOrVideoOrUrl instanceof HTMLImageElement) {
+            image = imageOrVideoOrUrl;
         } else {
             image = new Image();
-            image.src = imageOrUrl;
+            image.src = imageOrVideoOrUrl;
         }
         await QrScanner._awaitImageLoad(image);
         return image;
@@ -136,6 +552,7 @@ class QrScanner {
 
     /**
      * @param {HTMLImageElement} image
+     * @returns {Promise<void>}
      */
     static async _awaitImageLoad(image) {
         if (image.complete && image.naturalWidth !== 0) {
@@ -148,7 +565,7 @@ class QrScanner {
             const onLoad = () => { // eslint-disable-line require-jsdoc-except/require-jsdoc
                 image.removeEventListener('load', onLoad);
                 image.removeEventListener('error', onError);
-                resolve();
+                resolve(undefined);
             };
             onError = () => {
                 image.removeEventListener('load', onLoad);
@@ -159,6 +576,19 @@ class QrScanner {
             image.addEventListener('error', onError);
         });
     }
+
+    /**
+     * @param {Worker | Promise<Worker>} qrEngineOrQrEnginePromise
+     * @param {string} type
+     * @param {any} [data]
+     * @returns {Promise<void>}
+     */
+    static async _postWorkerMessage(qrEngineOrQrEnginePromise, type, data) {
+        const qrEngine = await qrEngineOrQrEnginePromise;
+        if (!(qrEngine instanceof Worker)) return;
+        qrEngine.postMessage({ type, data });
+    }
 }
 QrScanner.DEFAULT_CANVAS_SIZE = 400;
+QrScanner.NO_QR_CODE_FOUND = 'No QR code found';
 QrScanner.WORKER_PATH = '../../lib/QrScannerWorker.js';

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -430,16 +430,9 @@ class QrScanner {
         }, {}];
 
         if (facingMode) {
-            if (exact) {
-                const exactFacingMode = { exact: facingMode };
-                constraintsToTry.forEach(constraint => {
-                    constraint.facingMode = exactFacingMode;
-                });
-            } else {
-                constraintsToTry.forEach(constraint => {
-                    constraint.facingMode = facingMode;
-                });
-            }
+            constraintsToTry.forEach(constraint => {
+                constraint.facingMode = exact ? { exact: facingMode } : facingMode;
+            });
         }
         return this._getMatchingCameraStream(constraintsToTry);
     }
@@ -448,13 +441,17 @@ class QrScanner {
      * @param {MediaTrackConstraints[]} constraintsToTry
      * @returns {Promise<MediaStream>}
      */
-    _getMatchingCameraStream(constraintsToTry) {
+    async _getMatchingCameraStream(constraintsToTry) {
         if (!navigator.mediaDevices || constraintsToTry.length === 0) {
-            return Promise.reject('Camera not found.');
+            throw 'Camera not found.';
         }
-        return navigator.mediaDevices.getUserMedia({
-            video: constraintsToTry.shift(),
-        }).catch(() => this._getMatchingCameraStream(constraintsToTry));
+        try {
+            return await navigator.mediaDevices.getUserMedia({
+                video: constraintsToTry.shift(),
+            });
+        } catch (error) {
+            return this._getMatchingCameraStream(constraintsToTry);
+        }
     }
 
     /**

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -388,8 +388,6 @@ class QrScanner {
                     this._scanRegion,
                     this._qrEnginePromise,
                     this.$canvas,
-                    /* fixedCanvasSize */ true,
-                    /* alsoTryWitoutScanRegion */ false,
                 );
             } catch (error) {
                 if (!this._active) return;

--- a/src/request/import/Import.css
+++ b/src/request/import/Import.css
@@ -1,3 +1,7 @@
+.page#import-file {
+    position: relative;
+}
+
 .page#import-file .page-body,
 .page#unlock-account .page-body {
     display: flex;
@@ -21,6 +25,53 @@
 
 .page#import-file .page-footer {
     align-items: center;
+}
+
+.page#import-file .qr-video-button {
+    position: absolute;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    display: flex;
+
+    /* Reset Button */
+    background: none;
+    border: none;
+    outline: none;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    font-weight: inherit;
+    color: inherit;
+    text-align: inherit;
+    cursor: pointer;
+
+    font-size: 3.75rem;
+    opacity: 0.6;
+    transition: opacity 0.3s var(--nimiq-ease);
+}
+
+.page#import-file .qr-video-button:hover,
+.page#import-file .qr-video-button:focus {
+    opacity: 0.8;
+}
+
+.page#import-file .qr-video-scanner {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: 0.625rem;
+    margin: 0.75rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.7s var(--nimiq-ease);
+}
+
+.page#import-file .qr-video-scanner.active {
+    opacity: 1;
+    pointer-events: all;
 }
 
 .page#unlock-account .page-body {
@@ -163,4 +214,11 @@ a#goto-create {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+}
+
+@media (max-width: 450px) {
+    .page#import-file .qr-video-scanner {
+        margin: 0;
+        border-radius: 0;
+    }
 }

--- a/src/request/import/Import.css
+++ b/src/request/import/Import.css
@@ -47,13 +47,28 @@
     cursor: pointer;
 
     font-size: 3.75rem;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.page#import-file .qr-video-button .nq-icon {
     opacity: 0.6;
     transition: opacity 0.3s var(--nimiq-ease);
 }
 
-.page#import-file .qr-video-button:hover,
-.page#import-file .qr-video-button:focus {
+.page#import-file .qr-video-button:hover .nq-icon,
+.page#import-file .qr-video-button:focus .nq-icon {
     opacity: 0.8;
+}
+
+.page#import-file .qr-video-button .tooltip-box {
+    right: -.5rem;
+    width: 24rem;
+}
+
+.page#import-file .qr-video-button.hide-tooltip::after,
+.page#import-file .qr-video-button.hide-tooltip .tooltip-box {
+    visibility: hidden;
+    opacity: 0;
 }
 
 .page#import-file .qr-video-scanner {

--- a/src/request/import/ImportFile.js
+++ b/src/request/import/ImportFile.js
@@ -56,7 +56,7 @@ class ImportFile {
 
         /** @type {HTMLDivElement} */
         this.$qrVideoScanner = (this.$importFilePage.querySelector('.qr-video-scanner'));
-        this.qrVideoScanner = new QrVideoScanner(this.$qrVideoScanner, 7000, FileImporter.isLoginFileData);
+        this.qrVideoScanner = new QrVideoScanner(this.$qrVideoScanner, FileImporter.isLoginFileData);
 
         /** @type {HTMLElement} */
         const $gotoWords = (this.$importFilePage.querySelector('#goto-words'));

--- a/src/request/import/ImportFile.js
+++ b/src/request/import/ImportFile.js
@@ -10,6 +10,7 @@
 /* global Utf8Tools */
 /* global KeyStore */
 /* global BitcoinKey */
+/* global QrVideoScanner */
 
 /**
  * @callback ImportFile.resolve
@@ -50,6 +51,13 @@ class ImportFile {
         const $fileImport = (this.$importFilePage.querySelector('.file-import'));
         const fileImport = new FileImporter($fileImport, false);
 
+        /** @type {HTMLButtonElement} */
+        const $qrVideoButton = (this.$importFilePage.querySelector('.qr-video-button'));
+
+        /** @type {HTMLDivElement} */
+        this.$qrVideoScanner = (this.$importFilePage.querySelector('.qr-video-scanner'));
+        this.qrVideoScanner = new QrVideoScanner(this.$qrVideoScanner);
+
         /** @type {HTMLElement} */
         const $gotoWords = (this.$importFilePage.querySelector('#goto-words'));
         $gotoWords.addEventListener('click', () => { this.importWordsHandler.run(); });
@@ -71,6 +79,14 @@ class ImportFile {
         fileImport.on(FileImporter.Events.IMPORT, this._onFileImported.bind(this));
         this.passwordBox.on(PasswordBox.Events.SUBMIT, this._onPasswordEntered.bind(this));
 
+        this.qrVideoScanner.on(QrVideoScanner.Events.RESULT, result => {
+            this._onFileImported(result);
+            this._stopQrVideo();
+        });
+        this.qrVideoScanner.on(QrVideoScanner.Events.CANCEL, this._stopQrVideo.bind(this));
+
+        $qrVideoButton.addEventListener('click', this._startQrVideo.bind(this));
+
         if (request.enableBackArrow) {
             /** @type {HTMLElement} */
             (this.$importFilePage.querySelector('.page-header-back-button')).classList.remove('display-none');
@@ -83,7 +99,7 @@ class ImportFile {
 
     /**
      * @param {string} decoded
-     * @param {string} src
+     * @param {string} [src]
      */
     _onFileImported(decoded, src) {
         if (decoded.substr(0, 2) === '#2') {
@@ -105,7 +121,9 @@ class ImportFile {
         }
 
         // Prepare next page
-        this.$loginFileImage.src = src;
+        if (src) {
+            this.$loginFileImage.src = src;
+        }
         const version = this._encryptedKey.readUint8();
         // eslint-disable-next-line no-nested-ternary
         this.passwordBox.setMinLength(this._flags.hasPin ? Key.PIN_LENGTH : version < 3 ? 10 : undefined);
@@ -117,6 +135,17 @@ class ImportFile {
         setTimeout(() => this.$unlockAccountPage.classList.add('animate'), 0);
 
         TopLevelApi.focusPasswordBox();
+    }
+
+    _startQrVideo() {
+        this.qrVideoScanner.start();
+        this.qrVideoScanner.repositionOverlay();
+        this.$qrVideoScanner.classList.add('active');
+    }
+
+    _stopQrVideo() {
+        this.$qrVideoScanner.classList.remove('active');
+        window.setTimeout(() => this.qrVideoScanner.stop(), 1000);
     }
 
     /**

--- a/src/request/import/ImportFile.js
+++ b/src/request/import/ImportFile.js
@@ -52,7 +52,7 @@ class ImportFile {
         const fileImport = new FileImporter($fileImport, false);
 
         /** @type {HTMLButtonElement} */
-        const $qrVideoButton = (this.$importFilePage.querySelector('.qr-video-button'));
+        this.$qrVideoButton = (this.$importFilePage.querySelector('.qr-video-button'));
 
         /** @type {HTMLDivElement} */
         this.$qrVideoScanner = (this.$importFilePage.querySelector('.qr-video-scanner'));
@@ -85,7 +85,7 @@ class ImportFile {
         });
         this.qrVideoScanner.on(QrVideoScanner.Events.CANCEL, this._stopQrVideo.bind(this));
 
-        $qrVideoButton.addEventListener('click', this._startQrVideo.bind(this));
+        this.$qrVideoButton.addEventListener('click', this._startQrVideo.bind(this));
 
         if (request.enableBackArrow) {
             /** @type {HTMLElement} */
@@ -141,10 +141,12 @@ class ImportFile {
         this.qrVideoScanner.start();
         this.qrVideoScanner.repositionOverlay();
         this.$qrVideoScanner.classList.add('active');
+        this.$qrVideoButton.classList.add('hide-tooltip');
     }
 
     _stopQrVideo() {
         this.$qrVideoScanner.classList.remove('active');
+        this.$qrVideoButton.classList.remove('hide-tooltip');
         window.setTimeout(() => this.qrVideoScanner.stop(), 1000);
     }
 

--- a/src/request/import/ImportFile.js
+++ b/src/request/import/ImportFile.js
@@ -56,7 +56,7 @@ class ImportFile {
 
         /** @type {HTMLDivElement} */
         this.$qrVideoScanner = (this.$importFilePage.querySelector('.qr-video-scanner'));
-        this.qrVideoScanner = new QrVideoScanner(this.$qrVideoScanner);
+        this.qrVideoScanner = new QrVideoScanner(this.$qrVideoScanner, 7000, FileImporter.isLoginFileData);
 
         /** @type {HTMLElement} */
         const $gotoWords = (this.$importFilePage.querySelector('#goto-words'));

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -56,6 +56,7 @@
     <script defer src="../../lib/QrEncoder.js"></script>
     <script defer src="../../components/DownloadLoginFile.js"></script>
     <script defer src="../../components/FileImporter.js"></script>
+    <script defer src="../../components/QrVideoScanner.js"></script>
     <script defer src="../../components/FlippableHandler.js"></script>
     <script defer src="../../components/LoginFileIcon.js"></script>
     <script defer src="../../components/PasswordSetterBox.js"></script>
@@ -73,6 +74,7 @@
     <link rel="stylesheet" bundle-toplevel href="../../components/PasswordBox.css">
 
     <link rel="stylesheet" href="../../components/FileImporter.css">
+    <link rel="stylesheet" href="../../components/QrVideoScanner.css">
     <link rel="stylesheet" href="../../components/FlippableHandler.css">
     <link rel="stylesheet" href="../../components/LoginFileIcon.css">
     <link rel="stylesheet" href="../../components/RecoveryWords.css">
@@ -169,6 +171,11 @@
                         <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/></svg>
                     </a>
                 </div>
+
+                <button class="qr-video-button">
+                    <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-scan-qr-code"/></svg>
+                </button>
+                <div class="qr-video-scanner"></div>
             </div>
 
             <div id="unlock-account" class="page nq-card">

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -74,6 +74,7 @@
     <link rel="stylesheet" bundle-toplevel href="../../components/PasswordBox.css">
 
     <link rel="stylesheet" href="../../components/FileImporter.css">
+    <link rel="stylesheet" href="../../components/Tooltip.css">
     <link rel="stylesheet" href="../../components/QrVideoScanner.css">
     <link rel="stylesheet" href="../../components/FlippableHandler.css">
     <link rel="stylesheet" href="../../components/LoginFileIcon.css">
@@ -172,8 +173,11 @@
                     </a>
                 </div>
 
-                <button class="qr-video-button">
+                <button class="qr-video-button tooltip top">
                     <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-scan-qr-code"/></svg>
+                    <div data-i18n="import-qr-video-tooltip" class="tooltip-box" >
+                        Scan your Login File with your device's camera.
+                    </div>
                 </button>
                 <div class="qr-video-scanner"></div>
             </div>

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "Login-Datei nicht erkannt.",
     "file-import-error-invalid": "Ungültige Login‑Datei.",
 
+    "qr-video-scanner-cancel": "Abbrechen",
+
     "sign-tx-heading-tx": "Transaktion bestätigen",
     "sign-tx-heading-checkout": "Zahlung bestätigen",
     "sign-tx-heading-cashlink": "Cashlink erstellen",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Ungültige Login‑Datei.",
 
     "qr-video-scanner-cancel": "Abbrechen",
+    "qr-video-scanner-no-camera": "Dein Endgerät verfügt über keine verwendbare Kamera.",
+    "qr-video-scanner-enable-camera": "Erlaube den Zugriff auf deine Kamera, um QR-Codes zu scannen.",
 
     "sign-tx-heading-tx": "Transaktion bestätigen",
     "sign-tx-heading-checkout": "Zahlung bestätigen",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Bitte logge dich neu ein, um fortzufahren.",
     "import-unlock-account": "Entsperre dein Konto",
     "import-create-account": "Erstelle ein neues Konto",
+    "import-qr-video-tooltip": "Scanne deine Login-Datei mittels der Kamera deines Geräts.",
 
     "import-file-button-words": "Mit Wiederherstellungswörtern einloggen",
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -42,7 +42,7 @@
     "import-login-to-continue": "Bitte logge dich neu ein, um fortzufahren.",
     "import-unlock-account": "Entsperre dein Konto",
     "import-create-account": "Erstelle ein neues Konto",
-    "import-qr-video-tooltip": "Scanne deine Login-Datei mittels der Kamera deines Geräts.",
+    "import-qr-video-tooltip": "Scanne deine Login‑Datei mit der Kamera deines Geräts.",
 
     "import-file-button-words": "Mit Wiederherstellungswörtern einloggen",
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "Could not read Login File.",
     "file-import-error-invalid": "Invalid Login File.",
 
+    "qr-video-scanner-cancel": "Cancel",
+
     "sign-tx-heading-tx": "Confirm Transaction",
     "sign-tx-heading-checkout": "Verify Payment",
     "sign-tx-heading-cashlink": "Create a Cashlink",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Invalid Login File.",
 
     "qr-video-scanner-cancel": "Cancel",
+    "qr-video-scanner-no-camera": "Your device does not have an accessible camera.",
+    "qr-video-scanner-enable-camera": "Unblock the camera for this website to scan QR codes.",
 
     "sign-tx-heading-tx": "Confirm Transaction",
     "sign-tx-heading-checkout": "Verify Payment",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Please login again to continue.",
     "import-unlock-account": "Unlock your Account",
     "import-create-account": "Create new account",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "Login with Recovery Words",
 

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "No se pudo leer el Archivo de Sesión.",
     "file-import-error-invalid": "Archivo de Sesión inválido.",
 
+    "qr-video-scanner-cancel": "Cancelar",
+
     "sign-tx-heading-tx": "Confirme Transacción",
     "sign-tx-heading-checkout": "Verificar Pago",
     "sign-tx-heading-cashlink": "Crear un Cashlink",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Archivo de Sesión inválido.",
 
     "qr-video-scanner-cancel": "Cancelar",
+    "qr-video-scanner-no-camera": "Su dispositivo no tiene una cámara accesible.",
+    "qr-video-scanner-enable-camera": "Desbloquee la cámara para esta página para poder escanear códigos QR.",
 
     "sign-tx-heading-tx": "Confirme Transacción",
     "sign-tx-heading-checkout": "Verificar Pago",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Por favor inicie sesión de nuevo para continuar.",
     "import-unlock-account": "Desbloquear su Cuenta",
     "import-create-account": "Crear nueva cuenta",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "Inicie sesión con Palabras de Recuperación",
 

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "Impossible de lire le fichier de connexion.",
     "file-import-error-invalid": "Fichier de connexion invalide.",
 
+    "qr-video-scanner-cancel": "Annuler",
+
     "sign-tx-heading-tx": "Confirmer la Transaction",
     "sign-tx-heading-checkout": "Vérifier le Paiement",
     "sign-tx-heading-cashlink": "Créer un Cashlink",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Fichier de connexion invalide.",
 
     "qr-video-scanner-cancel": "Annuler",
+    "qr-video-scanner-no-camera": "Votre appareil n'a pas de caméra accessible.",
+    "qr-video-scanner-enable-camera": "Débloquez la caméra pour ce site de façon à scanner les QR codes.",
 
     "sign-tx-heading-tx": "Confirmer la Transaction",
     "sign-tx-heading-checkout": "Vérifier le Paiement",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Veuillez vous reconnecter pour continuer.",
     "import-unlock-account": "Déverrouiller votre Compte",
     "import-create-account": "Créer un nouveau compte",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "Se connecter avec les Mots de Récupération",
 

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Некорретный Файл Авторизации",
 
     "qr-video-scanner-cancel": "Отменить",
+    "qr-video-scanner-no-camera": "Камера вашего устройства недоступна.",
+    "qr-video-scanner-enable-camera": "Разблокируйте камеру для этого сайта, чтобы сканировать QR-коды.",
 
     "sign-tx-heading-tx": "Подтвердите транзакцию",
     "sign-tx-heading-checkout": "Проверьте Платёж",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "Файл Авторизации не прочитался",
     "file-import-error-invalid": "Некорретный Файл Авторизации",
 
+    "qr-video-scanner-cancel": "Отменить",
+
     "sign-tx-heading-tx": "Подтвердите транзакцию",
     "sign-tx-heading-checkout": "Проверьте Платёж",
     "sign-tx-heading-cashlink": "Создать Cashlink",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Чтобы продолжить, войдите снова",
     "import-unlock-account": "Разблокировать ваш Аккаунт",
     "import-create-account": "Создать новый аккаунт",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "Войти с помощью Защитной Фразы",
 

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "Невірний файл-ключ.",
 
     "qr-video-scanner-cancel": "Скасувати",
+    "qr-video-scanner-no-camera": "Ваш пристрій не має доступної камери.",
+    "qr-video-scanner-enable-camera": "Розблокуйте камеру для цього веб-сайту, щоб сканувати QR-коди.",
 
     "sign-tx-heading-tx": "Підтвердіть переказ",
     "sign-tx-heading-checkout": "Підтвердіть платіж",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "Неможливо прочитати файл-ключ.",
     "file-import-error-invalid": "Невірний файл-ключ.",
 
+    "qr-video-scanner-cancel": "Скасувати",
+
     "sign-tx-heading-tx": "Підтвердіть переказ",
     "sign-tx-heading-checkout": "Підтвердіть платіж",
     "sign-tx-heading-cashlink": "Створити чек",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "Будь ласка, увійдіть ще раз, щоб продовжити.",
     "import-unlock-account": "Розблокувати рахунок",
     "import-create-account": "Створити новий рахунок",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "Увійти за допомогою секретних слів",
 

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -57,6 +57,8 @@
     "file-import-error-invalid": "无效的登录文件",
 
     "qr-video-scanner-cancel": "取消",
+    "qr-video-scanner-no-camera": "您的设备没有可访问的相机",
+    "qr-video-scanner-enable-camera": "打开此网站相机的使用权限以扫描QR码",
 
     "sign-tx-heading-tx": "确认交易",
     "sign-tx-heading-checkout": "验证付款",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -56,6 +56,8 @@
     "file-import-error-could-not-read": "无法读取登录文件",
     "file-import-error-invalid": "无效的登录文件",
 
+    "qr-video-scanner-cancel": "取消",
+
     "sign-tx-heading-tx": "确认交易",
     "sign-tx-heading-checkout": "验证付款",
     "sign-tx-heading-cashlink": "创建现金链接",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -42,6 +42,7 @@
     "import-login-to-continue": "请再次登录以继续",
     "import-unlock-account": "解锁您的账户",
     "import-create-account": "建立新帐户",
+    "import-qr-video-tooltip": "Scan your Login File with your device's camera.",
 
     "import-file-button-words": "使用助记词登录",
 

--- a/tests/lib/LoginFile.spec.js
+++ b/tests/lib/LoginFile.spec.js
@@ -57,8 +57,8 @@ describe('LoginFile', () => {
         const qrPosition = LoginFile.calculateQrPosition();
 
         QrScanner.WORKER_PATH = '/base/src/lib/QrScannerWorker.js';
-        const decoded1 = await QrScanner.scanImage($img1, qrPosition, undefined, undefined, true);
-        const decoded2 = await QrScanner.scanImage($img2, qrPosition, undefined, undefined, true);
+        const decoded1 = await QrScanner.scanImage($img1, qrPosition, undefined, undefined, undefined, true);
+        const decoded2 = await QrScanner.scanImage($img2, qrPosition, undefined, undefined, undefined, true);
         expect(decoded1).toEqual(serializedEntropy);
         expect(decoded2).toEqual(serializedEntropyWithLabel);
 

--- a/tests/lib/LoginFile.spec.js
+++ b/tests/lib/LoginFile.spec.js
@@ -57,8 +57,8 @@ describe('LoginFile', () => {
         const qrPosition = LoginFile.calculateQrPosition();
 
         QrScanner.WORKER_PATH = '/base/src/lib/QrScannerWorker.js';
-        const decoded1 = await QrScanner.scanImage($img1, qrPosition, undefined, undefined, undefined, true);
-        const decoded2 = await QrScanner.scanImage($img2, qrPosition, undefined, undefined, undefined, true);
+        const decoded1 = await QrScanner.scanImage($img1, qrPosition, undefined, undefined, true);
+        const decoded2 = await QrScanner.scanImage($img2, qrPosition, undefined, undefined, true);
         expect(decoded1).toEqual(serializedEntropy);
         expect(decoded2).toEqual(serializedEntropyWithLabel);
 

--- a/tests/lib/LoginFile.spec.js
+++ b/tests/lib/LoginFile.spec.js
@@ -57,8 +57,8 @@ describe('LoginFile', () => {
         const qrPosition = LoginFile.calculateQrPosition();
 
         QrScanner.WORKER_PATH = '/base/src/lib/QrScannerWorker.js';
-        const decoded1 = await QrScanner.scanImage($img1, qrPosition, null, null, true);
-        const decoded2 = await QrScanner.scanImage($img2, qrPosition, null, null, true);
+        const decoded1 = await QrScanner.scanImage($img1, qrPosition, undefined, undefined, true);
+        const decoded2 = await QrScanner.scanImage($img2, qrPosition, undefined, undefined, true);
         expect(decoded1).toEqual(serializedEntropy);
         expect(decoded2).toEqual(serializedEntropyWithLabel);
 

--- a/tools/dependencyValidator.js
+++ b/tools/dependencyValidator.js
@@ -12,6 +12,7 @@ class2Path.set('TRANSLATIONS', 'src/translations/index.js');
 class2Path.set('CONFIG', 'src/config/config.local.js');
 class2Path.set('Nimiq', 'node_modules/@nimiq/core-web/web-offline.js');
 class2Path.set('Rpc', 'node_modules/@nimiq/rpc/dist/rpc.umd.js');
+class2Path.set('BarcodeDetector', 'src/lib/QrScanner.js');
 class2Path.delete('index');
 
 const requests = funcs.listDirectories('src/request');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
     /* Basic Options */
     "target": "ES2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-     "allowJs": true,                         /* Allow javascript files to be compiled. */
-     "checkJs": true,                         /* Report errors in .js files. */
+    "lib": ["DOM"],                           /* Specify library files to be included in the compilation. */
+    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    "checkJs": true,                          /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
     "types/Keyguard.d.ts",
     "types/ErrorContainer.d.ts",
     "types/MessagePrefix.d.ts",
+    "types/BarcodeScanner.d.ts",
     "types/BitcoinJS.d.ts",
     "src/**/*.js",
     "tests/**/*.js"

--- a/types/BarcodeScanner.d.ts
+++ b/types/BarcodeScanner.d.ts
@@ -1,0 +1,6 @@
+// simplified from https://wicg.github.io/shape-detection-api/#barcode-detection-api
+declare class BarcodeDetector {
+    constructor(options?: { formats: string[] });
+    static getSupportedFormats(): Promise<string[]>;
+    detect(image: ImageBitmapSource): Promise<Array<{ rawValue: string }>>;
+}


### PR DESCRIPTION
Fixes #364

This PR extends the `QrScanner` library with the ability to scan live video for QR codes, converted from https://github.com/nimiq/qr-scanner.

It then adds a `QrVideoScanner` component to encapsulate the scanner. Also includes already-translated strings, taken from the nimiq/vue-components translations.

~~There is a workaround for the "BarcodeScanner", which is sadly not yet recognized by Typescript and thus cannot be used for types.~~