### PR TITLE
Password input alignment on mobile (except iOS)

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -1,6 +1,7 @@
 /* global Nimiq */
 /* global I18n */
 /* global TemplateTags */
+/* global BrowserDetection */
 
 class PasswordInput extends Nimiq.Observable {
     /**
@@ -26,6 +27,14 @@ class PasswordInput extends Nimiq.Observable {
 
         this._onInputChanged();
         this.$input.addEventListener('input', () => this._onInputChanged());
+
+        // Scroll parent into view on mobile devices (except iOS) when input is focused and on 'input'
+        // to prevent the submit button from being (partially) hidden behind the virtual keyboard
+        if (BrowserDetection.isMobile() && BrowserDetection.isTouchDevice() && !BrowserDetection.isIOS()) {
+            // 700ms to wait for on-screen keyboard to be visible, for most devices
+            this.$input.addEventListener('focus', () => setTimeout(() => this.scrollParentIntoView(), 700));
+            this.$input.addEventListener('input', () => this.scrollParentIntoView());
+        }
     }
 
     /**
@@ -107,6 +116,17 @@ class PasswordInput extends Nimiq.Observable {
      */
     setMinLength(minLength) {
         this._minLength = minLength || PasswordInput.DEFAULT_MIN_LENGTH;
+    }
+
+    scrollParentIntoView() {
+        const $parent = this.$el.parentElement;
+
+        if (!$parent) return;
+
+        $parent.scrollIntoView({
+            behavior: 'smooth',
+            block: 'end',
+        });
     }
 }
 

--- a/src/lib/BrowserDetection.js
+++ b/src/lib/BrowserDetection.js
@@ -43,4 +43,20 @@ class BrowserDetection { // eslint-disable-line no-unused-vars
         const version = this.iOSVersion();
         return version[0] < 11 || (version[0] === 11 && version[1] === 2); // Only 11.2 has the WASM bug
     }
+
+    /**
+     * @returns {boolean}
+     */
+    static isMobile() {
+        return window.matchMedia('only screen and (max-width: 760px)').matches;
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    static isTouchDevice() {
+        return (('ontouchstart' in window)
+            || (navigator.maxTouchPoints > 0)
+            || (navigator.msMaxTouchPoints > 0));
+    }
 }


### PR DESCRIPTION
This PR add a small change to prevent the password input, or the submit button present below it, from being (partially) hidden behind the on-screen keyboard when typing password.
What it does is simply scroll back the PasswordBox (or any PasswordInput parent) into view on focus of input.

**This does not work on iOS!**