### PR TITLE
Ten31 Pass support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -213,7 +213,7 @@ export type SettlementInstruction = MockSettlementInstruction | SepaSettlementIn
 
 export type SignSwapRequestLayout = 'standard' | 'slider';
 
-export type KycProvider = 'TEN31 PASS';
+export type KycProvider = 'TEN31 Pass';
 
 export type SignSwapRequestCommon = SimpleRequest & {
     swapId: string,

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -213,6 +213,8 @@ export type SettlementInstruction = MockSettlementInstruction | SepaSettlementIn
 
 export type SignSwapRequestLayout = 'standard' | 'slider';
 
+export type KycProvider = 'TEN31 PASS';
+
 export type SignSwapRequestCommon = SimpleRequest & {
     swapId: string,
     fund: (
@@ -294,6 +296,15 @@ export type SignSwapRequestCommon = SimpleRequest & {
         processing: number,
     },
     serviceSwapFee: number, // Luna, Sats or Cents, depending which one gets funded
+
+    // Optional KYC info for swapping at higher limits.
+    // KYC-enabled swaps facilitated by S3/Fastspot require an s3GrantToken and swaps from or to Euro via OASIS
+    // additionally require a clearing or settlement specific oasisGrantToken.
+    kyc?: {
+        provider: KycProvider,
+        s3GrantToken: string,
+        oasisGrantToken?: string,
+    };
 };
 
 export type SignSwapRequestStandard = SignSwapRequestCommon & {

--- a/src/components/PasswordBox.css
+++ b/src/components/PasswordBox.css
@@ -3,20 +3,36 @@
     padding: 5.5rem 1.25rem 1.25rem;
 }
 
+.password-box .prompt {
+    margin-top: -2.75rem;
+    line-height: 1;
+    pointer-events: none;
+}
+
 .password-box .password-input {
     margin: 5rem 0 4.5rem 0;
 }
-.password-box .password-input ~ .submit {
-    margin-top: -6.375rem; /* -8 from button + 1.625 from missing skip button */
+
+.password-box .password-input .input-container {
+    position: static;
 }
 
 .password-box .password-input .input-wrapper {
     transition: transform 300ms var(--nimiq-ease)!important;
 }
 
-.password-box.input-eligible .password-input .input-wrapper,
-.password-box.hide-input .password-input .input-wrapper {
+.password-box.input-eligible .password-input .input-wrapper {
     transform: translate(0, -3.5rem);
+}
+
+.password-box .password-input input {
+    text-align: center;
+    width: 100%;
+}
+
+.password-box .password-input .eye-button {
+    top: 1.5rem;
+    left: 2rem;
 }
 
 .password-box.hide-input .prompt,
@@ -26,7 +42,7 @@
 }
 
 .password-box .submit {
-    margin: -8rem auto 0.75rem;
+    margin: -6.375rem auto 0.75rem;
     opacity: 0;
     transition:
         transform 450ms cubic-bezier(.25,0,0,1), /* From @nimiq/style */
@@ -43,13 +59,16 @@
     pointer-events: all;
 }
 
-.password-box .prompt {
-    margin-top: -2.75rem;
-    line-height: 1;
-    pointer-events: none;
+.password-box .skip {
+    opacity: 1;
+    margin-top: -3.5rem;
 }
 
-/* S E T T E R */
+.password-box.input-eligible .skip {
+    opacity: 0;
+}
+
+/* SETTER */
 .password-box .repeat-password,
 .password-box .password-strength,
 .password-box .repeat-short,
@@ -95,27 +114,4 @@
 .password-box.repeat .submit:not(.show-in-repeat),
 .password-box:not(.repeat) .submit.show-in-repeat {
     display: none;
-}
-
-.password-box .password-input .input-container {
-    position: static;
-}
-
-.password-box .password-input .eye-button {
-    top: 1.5rem;
-    left: 2rem;
-}
-
-.password-box input {
-    text-align: center;
-    width: 100%;
-}
-
-.password-box .skip {
-    opacity: 1;
-    margin-top: -3.5rem;
-}
-
-.password-box.input-eligible .skip {
-    opacity: 0;
 }

--- a/src/components/PasswordBox.css
+++ b/src/components/PasswordBox.css
@@ -7,7 +7,6 @@
     margin-top: -2.75rem;
     line-height: 1;
     pointer-events: none;
-    transition: opacity .3s;
 }
 
 .password-box .password-input {
@@ -72,34 +71,23 @@
 
 .password-box.show-swap-authorization {
     overflow: hidden;
-    isolation: isolate; /* separate stacking context to avoid putting the ::before element behind the password box */
 }
-.password-box.show-swap-authorization::before {
-    content: '';
+.password-box.show-swap-authorization::after {
+    content: attr(data-i18n-swap-authorization-caption);
     position: absolute;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
-    background-image: radial-gradient(100% 100% at 100% 100%, #4D4C96 0%, #5F4B8B 100%);
-    animation: fade 1s 1.5s reverse forwards; /* 2.5s total */
-    z-index: -1; /* put behind other children of the password box */
-}
-.password-box.show-swap-authorization .prompt {
-    position: relative;
-    width: max-content;
-    padding-left: 1.5rem;
-    margin-left: auto;
-    margin-right: auto;
-    /* Set opacity to initially 0 such that the prompt gets faded in after the show-swap-authorization class gets
-    removed. While the class is still set, the effective value will be determined by the animation. */
-    opacity: 0;
-    animation: fade .4s 2.1s reverse backwards; /* 2.5s total */
-}
-.password-box.show-swap-authorization .prompt::before {
-    content: url('data:image/svg+xml,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M6.9.3a1.41 1.41 0 0 0-2.16.57l-.48 1.17c-.2.47-.62.8-1.12.86l-1.25.17A1.41 1.41 0 0 0 .76 5l.49 1.16c.2.47.12 1-.19 1.4l-.77 1c-.56.75-.28 1.82.58 2.17l1.17.49c.47.19.8.62.86 1.12l.17 1.25A1.41 1.41 0 0 0 5 14.72l1.16-.48c.47-.2 1-.13 1.4.18l1 .77c.75.57 1.82.28 2.17-.58l.49-1.16c.19-.47.62-.8 1.12-.87l1.25-.16a1.41 1.41 0 0 0 1.12-1.94l-.48-1.17c-.2-.46-.13-1 .18-1.4l.77-1c.57-.74.28-1.81-.58-2.17l-1.16-.48c-.47-.2-.8-.62-.87-1.12l-.16-1.25A1.41 1.41 0 0 0 10.48.76l-1.17.49c-.46.2-1 .12-1.4-.19L6.9.3Zm4.03 6.25a.66.66 0 0 0-.92-.95L6.83 8.66l-1.35-1.3a.66.66 0 1 0-.92.95l1.81 1.76c.26.24.67.24.93 0l3.63-3.52Z" fill="white"/></svg>');
-    position: absolute; /* to avoid affecting the height of the prompt */
-    left: -1.25rem;
+    padding-top: 8.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.5rem;
+    pointer-events: none;
+    background: /* kyc icon */ url('data:image/svg+xml,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M6.9.3a1.41 1.41 0 0 0-2.16.57l-.48 1.17c-.2.47-.62.8-1.12.86l-1.25.17A1.41 1.41 0 0 0 .76 5l.49 1.16c.2.47.12 1-.19 1.4l-.77 1c-.56.75-.28 1.82.58 2.17l1.17.49c.47.19.8.62.86 1.12l.17 1.25A1.41 1.41 0 0 0 5 14.72l1.16-.48c.47-.2 1-.13 1.4.18l1 .77c.75.57 1.82.28 2.17-.58l.49-1.16c.19-.47.62-.8 1.12-.87l1.25-.16a1.41 1.41 0 0 0 1.12-1.94l-.48-1.17c-.2-.46-.13-1 .18-1.4l.77-1c.57-.74.28-1.81-.58-2.17l-1.16-.48c-.47-.2-.8-.62-.87-1.12l-.16-1.25A1.41 1.41 0 0 0 10.48.76l-1.17.49c-.46.2-1 .12-1.4-.19L6.9.3Zm4.03 6.25a.66.66 0 0 0-.92-.95L6.83 8.66l-1.35-1.3a.66.66 0 1 0-.92.95l1.81 1.76c.26.24.67.24.93 0l3.63-3.52Z" fill="white"/></svg>') no-repeat center calc(50% /* move icon down */ - 2.5rem) / /* icon size */ 6.5rem,
+        /* purple gradient */ radial-gradient(100% 100% at 100% 100%, #4D4C96 0%, #5F4B8B 100%);
+    animation: fade 2.5s 1s reverse forwards;
 }
 
 /* SETTER */

--- a/src/components/PasswordBox.css
+++ b/src/components/PasswordBox.css
@@ -7,6 +7,7 @@
     margin-top: -2.75rem;
     line-height: 1;
     pointer-events: none;
+    transition: opacity .3s;
 }
 
 .password-box .password-input {
@@ -67,6 +68,38 @@
 .password-box.input-eligible .skip {
     opacity: 0;
     pointer-events: none;
+}
+
+.password-box.show-swap-authorization {
+    overflow: hidden;
+    isolation: isolate; /* separate stacking context to avoid putting the ::before element behind the password box */
+}
+.password-box.show-swap-authorization::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-image: radial-gradient(100% 100% at 100% 100%, #4D4C96 0%, #5F4B8B 100%);
+    animation: fade 1s 1.5s reverse forwards; /* 2.5s total */
+    z-index: -1; /* put behind other children of the password box */
+}
+.password-box.show-swap-authorization .prompt {
+    position: relative;
+    width: max-content;
+    padding-left: 1.5rem;
+    margin-left: auto;
+    margin-right: auto;
+    /* Set opacity to initially 0 such that the prompt gets faded in after the show-swap-authorization class gets
+    removed. While the class is still set, the effective value will be determined by the animation. */
+    opacity: 0;
+    animation: fade .4s 2.1s reverse backwards; /* 2.5s total */
+}
+.password-box.show-swap-authorization .prompt::before {
+    content: url('data:image/svg+xml,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M6.9.3a1.41 1.41 0 0 0-2.16.57l-.48 1.17c-.2.47-.62.8-1.12.86l-1.25.17A1.41 1.41 0 0 0 .76 5l.49 1.16c.2.47.12 1-.19 1.4l-.77 1c-.56.75-.28 1.82.58 2.17l1.17.49c.47.19.8.62.86 1.12l.17 1.25A1.41 1.41 0 0 0 5 14.72l1.16-.48c.47-.2 1-.13 1.4.18l1 .77c.75.57 1.82.28 2.17-.58l.49-1.16c.19-.47.62-.8 1.12-.87l1.25-.16a1.41 1.41 0 0 0 1.12-1.94l-.48-1.17c-.2-.46-.13-1 .18-1.4l.77-1c.57-.74.28-1.81-.58-2.17l-1.16-.48c-.47-.2-.8-.62-.87-1.12l-.16-1.25A1.41 1.41 0 0 0 10.48.76l-1.17.49c-.46.2-1 .12-1.4-.19L6.9.3Zm4.03 6.25a.66.66 0 0 0-.92-.95L6.83 8.66l-1.35-1.3a.66.66 0 1 0-.92.95l1.81 1.76c.26.24.67.24.93 0l3.63-3.52Z" fill="white"/></svg>');
+    position: absolute; /* to avoid affecting the height of the prompt */
+    left: -1.25rem;
 }
 
 /* SETTER */

--- a/src/components/PasswordBox.css
+++ b/src/components/PasswordBox.css
@@ -66,6 +66,7 @@
 
 .password-box.input-eligible .skip {
     opacity: 0;
+    pointer-events: none;
 }
 
 /* SETTER */

--- a/src/components/PasswordBox.js
+++ b/src/components/PasswordBox.js
@@ -118,11 +118,9 @@ class PasswordBox extends Nimiq.Observable {
         /* eslint-enable max-len */
 
         /** @type {HTMLButtonElement} */
-        ($el.querySelector('button.submit')).classList.add('nq-button', options.bgColor);
-        if (!options.hideInput) {
-            /** @type {HTMLButtonElement} */
-            ($el.querySelector('button.submit')).classList.add('inverse');
-        }
+        const submitButton = ($el.querySelector('button.submit'));
+        submitButton.classList.add('nq-button', options.bgColor);
+        submitButton.classList.toggle('inverse', !options.hideInput);
 
         I18n.translateDom($el);
         return $el;

--- a/src/components/PasswordBox.js
+++ b/src/components/PasswordBox.js
@@ -96,16 +96,11 @@ class PasswordBox extends Nimiq.Observable {
                     </svg>
                 <a>`
             : '';
-
-        /** @type {{[i18nTag: string]: string}} */
-        const promptVersions = {
-            'passwordbox-enter-password': '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-password">Enter your password</div>',
-            'passwordbox-enter-pin': '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-pin">Enter your PIN</div>',
-            'passwordbox-swap-authorized': '<div class="prompt nq-text-s" data-i18n="passwordbox-swap-authorized">Swap authorized</div>',
-        };
-        const promptHtml = promptVersions[options.showSwapAuthorization && !options.hideInput ? 'passwordbox-swap-authorized'
-            : options.minLength === Key.PIN_LENGTH ? 'passwordbox-enter-pin' : 'passwordbox-enter-password'];
         /* eslint-enable max-len */
+
+        const promptHtml = options.minLength === Key.PIN_LENGTH
+            ? '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-pin">Enter your PIN</div>'
+            : '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-password">Enter your password</div>';
 
         /* eslint-disable max-len */
         $el.innerHTML = TemplateTags.hasVars(3)`
@@ -127,19 +122,10 @@ class PasswordBox extends Nimiq.Observable {
         submitButton.classList.toggle('inverse', !options.hideInput);
 
         if (options.showSwapAuthorization && !options.hideInput) {
-            /** @type {HTMLDivElement} */
-            const $prompt = ($el.querySelector('.prompt'));
+            $el.dataset.i18nSwapAuthorizationCaption = I18n.translatePhrase('passwordbox-swap-authorized');
             AnimationUtils.animate('show-swap-authorization', $el, undefined, () => {
                 options.showSwapAuthorization = false;
-                // Apply the translation via translatePhrase such that the translationValidator finds it and also
-                // apply the data-i18n attribute such that the translation can be updated on language switch.
-                if (options.minLength === Key.PIN_LENGTH) {
-                    $prompt.textContent = I18n.translatePhrase('passwordbox-enter-pin');
-                    $prompt.dataset.i18n = 'passwordbox-enter-pin';
-                } else {
-                    $prompt.textContent = I18n.translatePhrase('passwordbox-enter-password');
-                    $prompt.dataset.i18n = 'passwordbox-enter-password';
-                }
+                delete (/** @type {HTMLFormElement} */ ($el)).dataset.i18nSwapAuthorizationCaption;
             });
         }
 

--- a/src/components/PasswordBox.js
+++ b/src/components/PasswordBox.js
@@ -12,6 +12,7 @@
  *      buttonI18nTag: string,
  *      minLength: number,
  *      showResetPassword: boolean,
+ *      showSwapAuthorization: boolean,
  *  }} PasswordBoxOptions
  */
 
@@ -28,6 +29,7 @@ class PasswordBox extends Nimiq.Observable {
             buttonI18nTag: 'passwordbox-confirm-tx',
             minLength: PasswordInput.DEFAULT_MIN_LENGTH,
             showResetPassword: false,
+            showSwapAuthorization: false,
         };
 
         super();
@@ -83,6 +85,7 @@ class PasswordBox extends Nimiq.Observable {
             'passwordbox-sign-msg': '<button class="submit" data-i18n="passwordbox-sign-msg">Sign message</button>',
             'passwordbox-confirm-swap': '<button class="submit" data-i18n="passwordbox-confirm-swap">Confirm swap</button>',
         };
+        if (!buttonVersions[options.buttonI18nTag]) throw new Error('PasswordBox button i18n tag not defined');
 
         const resetPasswordHtml = options.showResetPassword
             ? TemplateTags.noVars`
@@ -98,14 +101,15 @@ class PasswordBox extends Nimiq.Observable {
         const promptVersions = {
             'passwordbox-enter-password': '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-password">Enter your password</div>',
             'passwordbox-enter-pin': '<div class="prompt nq-text-s" data-i18n="passwordbox-enter-pin">Enter your PIN</div>',
+            'passwordbox-swap-authorized': '<div class="prompt nq-text-s" data-i18n="passwordbox-swap-authorized">Swap authorized</div>',
         };
+        const promptHtml = promptVersions[options.showSwapAuthorization && !options.hideInput ? 'passwordbox-swap-authorized'
+            : options.minLength === Key.PIN_LENGTH ? 'passwordbox-enter-pin' : 'passwordbox-enter-password'];
         /* eslint-enable max-len */
-
-        if (!buttonVersions[options.buttonI18nTag]) throw new Error('PasswordBox button i18n tag not defined');
 
         /* eslint-disable max-len */
         $el.innerHTML = TemplateTags.hasVars(3)`
-            ${promptVersions[options.minLength === Key.PIN_LENGTH ? 'passwordbox-enter-pin' : 'passwordbox-enter-password']}
+            ${promptHtml}
             <div password-input></div>
             ${buttonVersions[options.buttonI18nTag]}
             <!-- Loading spinner SVG -->
@@ -121,6 +125,23 @@ class PasswordBox extends Nimiq.Observable {
         const submitButton = ($el.querySelector('button.submit'));
         submitButton.classList.add('nq-button', options.bgColor);
         submitButton.classList.toggle('inverse', !options.hideInput);
+
+        if (options.showSwapAuthorization && !options.hideInput) {
+            /** @type {HTMLDivElement} */
+            const $prompt = ($el.querySelector('.prompt'));
+            AnimationUtils.animate('show-swap-authorization', $el, undefined, () => {
+                options.showSwapAuthorization = false;
+                // Apply the translation via translatePhrase such that the translationValidator finds it and also
+                // apply the data-i18n attribute such that the translation can be updated on language switch.
+                if (options.minLength === Key.PIN_LENGTH) {
+                    $prompt.textContent = I18n.translatePhrase('passwordbox-enter-pin');
+                    $prompt.dataset.i18n = 'passwordbox-enter-pin';
+                } else {
+                    $prompt.textContent = I18n.translatePhrase('passwordbox-enter-password');
+                    $prompt.dataset.i18n = 'passwordbox-enter-password';
+                }
+            });
+        }
 
         I18n.translateDom($el);
         return $el;

--- a/src/nimiq-style.css
+++ b/src/nimiq-style.css
@@ -36,6 +36,11 @@
     animation: shake-background .4s ease;
 }
 
+@keyframes fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
 /**************
 ** layout.js **
 ***************/

--- a/src/request/sign-swap/SignSwap.js
+++ b/src/request/sign-swap/SignSwap.js
@@ -353,6 +353,7 @@ class SignSwap {
             hideInput: !request.keyInfo.encrypted,
             buttonI18nTag: 'passwordbox-confirm-swap',
             minLength: request.keyInfo.hasPin ? Key.PIN_LENGTH : undefined,
+            showSwapAuthorization: !!request.kyc,
         });
 
         this._passwordBox.on(

--- a/src/request/sign-swap/SignSwapApi.js
+++ b/src/request/sign-swap/SignSwapApi.js
@@ -180,6 +180,25 @@ class SignSwapApi extends BitcoinRequestParserMixin(TopLevelApi) {
             }
         }
 
+        // Parse optional KYC data
+        if (request.kyc) {
+            if (request.kyc.provider !== 'TEN31 PASS') {
+                throw new Errors.InvalidRequestError(`Unsupported KYC provider: ${request.kyc.provider}`);
+            }
+            // TODO verify JWT tokens
+            if (typeof request.kyc.s3GrantToken !== 'string' || !request.kyc.s3GrantToken) {
+                throw new Error('Invalid KYC S3 grant token');
+            }
+            if (request.kyc.oasisGrantToken !== undefined
+                && (typeof request.kyc.oasisGrantToken !== 'string' || !request.kyc.oasisGrantToken)) {
+                throw new Error('Invalid KYC OASIS grant token');
+            } else if (!request.kyc.oasisGrantToken
+                && (parsedRequest.fund.type === 'EUR' || parsedRequest.redeem.type === 'EUR')) {
+                throw new Error('An OASIS grant token is required for KYC enabled EUR swaps');
+            }
+            parsedRequest.kyc = request.kyc;
+        }
+
         return parsedRequest;
     }
 

--- a/src/request/sign-swap/SignSwapApi.js
+++ b/src/request/sign-swap/SignSwapApi.js
@@ -182,7 +182,7 @@ class SignSwapApi extends BitcoinRequestParserMixin(TopLevelApi) {
 
         // Parse optional KYC data
         if (request.kyc) {
-            if (request.kyc.provider !== 'TEN31 PASS') {
+            if (request.kyc.provider !== 'TEN31 Pass') {
                 throw new Errors.InvalidRequestError(`Unsupported KYC provider: ${request.kyc.provider}`);
             }
             // TODO verify JWT tokens

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "Gebühr",
     "sign-tx-cancel-payment": "Zahlung abbrechen",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "Nachricht signieren",
     "sign-msg-signer": "Unterzeichner",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Gib dein Passwort ein",
     "passwordbox-enter-pin": "Gib deine PIN ein",
+    "passwordbox-swap-authorized": "Tausch autorisiert",
     "passwordbox-repeat-password": "Wiederhole dein Passwort",
     "passwordbox-repeat": "Passwort wiederholen",
     "passwordbox-continue": "Weiter",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Das Passwort ist zu kurz",
     "passwordbox-password-skip": "Erstmal überspringen",
     "passwordbox-reset-password": "Mit Wiederherstellungswörtern zurücksetzen",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "Kaufbetrag",
     "payment-info-line-vendor-markup": "Krypto-Aufschlag des Verkäufers",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Tauschgebühr",
     "sign-swap-of-exchange-value": "des Tauschwerts.",
     "sign-swap-total-fees": "Gebühren gesamt",
-    "sign-swap-your-bank": "Deine Bank",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "Deine Bank"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -79,6 +79,7 @@
 
     "passwordbox-enter-password": "Enter your password",
     "passwordbox-enter-pin": "Enter your PIN",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Repeat your password",
     "passwordbox-repeat": "Repeat password",
     "passwordbox-continue": "Continue",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "cuota",
     "sign-tx-cancel-payment": "Cancelar pago",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "Firmar Mensaje",
     "sign-msg-signer": "Firmador",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Ingrese su contraseña",
     "passwordbox-enter-pin": "Ingrese su PIN",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Repita su contraseña",
     "passwordbox-repeat": "Repita contraseña",
     "passwordbox-continue": "Continue",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "La contraseña es muy corta",
     "passwordbox-password-skip": "Salar por ahora",
     "passwordbox-reset-password": "Reiniciar con Palabras de Recuperación",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "Monto de orden",
     "payment-info-line-vendor-markup": "Margen del vendedor en cripto",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Cuotas de intercambio",
     "sign-swap-of-exchange-value": "del valor del intercambio.",
     "sign-swap-total-fees": "Cuotas totales",
-    "sign-swap-your-bank": "Su banco",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "Su banco"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "frais",
     "sign-tx-cancel-payment": "Annuler le paiement",
 
-    "sign-multisig-tx-heading-tx": "Approuver la transaction Multisig",
-    "sign-multisig-tx-approving-as": "Approuver en tant que",
-    "sign-multisig-tx-with": "avec",
-    "sign-multisig-tx-approving-with": "Approuver avec",
-
     "sign-msg-heading": "Signer le Message",
     "sign-msg-signer": "Signataire",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Entrez votre mot de passe",
     "passwordbox-enter-pin": "Entrez votre PIN",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Répétez votre mot de passe",
     "passwordbox-repeat": "Répéter le mot de passe",
     "passwordbox-continue": "Continuer",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Le mot de passe est trop court",
     "passwordbox-password-skip": "Ignorer pour l'instant",
     "passwordbox-reset-password": "Réinitialiser avec les mots de récupération",
-    "passwordbox-connect-account": "Connectez votre compte",
 
     "payment-info-line-order-amount": "Montant de la commande",
     "payment-info-line-vendor-markup": "Crypto-premium",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Frais de swap",
     "sign-swap-of-exchange-value": "de la valeur du swap.",
     "sign-swap-total-fees": "Total des frais",
-    "sign-swap-your-bank": "Votre banque",
-
-    "connect-heading-prefix": "Connectez-vous à"
+    "sign-swap-your-bank": "Votre banque"
 }

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "kosten",
     "sign-tx-cancel-payment": "Annuleer betaling",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "Bericht ondertekenen",
     "sign-msg-signer": "Ondertekenaar",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Vul wachtwoord in",
     "passwordbox-enter-pin": "Vul PIN in",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Herhaal je wachtwoord",
     "passwordbox-repeat": "Herhaal wachtwoord",
     "passwordbox-continue": "Doorgaan",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Wachtwoord is te kort",
     "passwordbox-password-skip": "Voor nu overslaan",
     "passwordbox-reset-password": "Resetten met herstelwoorden",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "Orderbedrag",
     "payment-info-line-vendor-markup": "Crypto leverancier opmaak",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Wisselkosten",
     "sign-swap-of-exchange-value": "van ruilwaarde.",
     "sign-swap-total-fees": "Totale kosten",
-    "sign-swap-your-bank": "Jouw bank",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "Jouw bank"
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "taxa",
     "sign-tx-cancel-payment": "Cancelar pagamento",
 
-    "sign-multisig-tx-heading-tx": "Aprovar transação Multisig",
-    "sign-multisig-tx-approving-as": "Aprovar como",
-    "sign-multisig-tx-with": "com",
-    "sign-multisig-tx-approving-with": "Aprovar com",
-
     "sign-msg-heading": "Assinar Mensagem",
     "sign-msg-signer": "Signatário",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Insira a sua palavra passe",
     "passwordbox-enter-pin": "Insira o seu PIN",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Repita a sua palavra passe",
     "passwordbox-repeat": "Repita a palavra passe",
     "passwordbox-continue": "Continuar",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Palavra passe demasiado curta",
     "passwordbox-password-skip": "Passar por enquanto",
     "passwordbox-reset-password": "Redefinir com as Palavras de Backup",
-    "passwordbox-connect-account": "Conecte a sua conta",
 
     "payment-info-line-order-amount": "Valor do pedido",
     "payment-info-line-vendor-markup": "Margem de lucro do vendedor da criptomoeda",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "taxa de troca",
     "sign-swap-of-exchange-value": "de troca de valor",
     "sign-swap-total-fees": "Taxas totais",
-    "sign-swap-your-bank": "O seu banco",
-
-    "connect-heading-prefix": "Login em"
+    "sign-swap-your-bank": "O seu banco"
 }

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "комиссия",
     "sign-tx-cancel-payment": "Отменить платёж",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "Подписать сообщение",
     "sign-msg-signer": "Отправитель",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Введите ваш пароль",
     "passwordbox-enter-pin": "Введите ваш PIN-код",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Повторите ваш пароль",
     "passwordbox-repeat": "Повторите пароль",
     "passwordbox-continue": "Продолжить",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Пароль слишком короткий",
     "passwordbox-password-skip": "Пока отложить",
     "passwordbox-reset-password": "Сбросить, используя Защитную Фразу",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "Сумма заказа",
     "payment-info-line-vendor-markup": "Маркап вендора криптовалюты",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Комиссия",
     "sign-swap-of-exchange-value": "от суммы обмена.",
     "sign-swap-total-fees": "Итого",
-    "sign-swap-your-bank": "Ваш банк",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "Ваш банк"
 }

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "комісія",
     "sign-tx-cancel-payment": "Скасувати платіж",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "Підписати повідомлення",
     "sign-msg-signer": "Підписант",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "Введіть пароль",
     "passwordbox-enter-pin": "Уведіть PIN",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "Повторіть пароль",
     "passwordbox-repeat": "Повторіть пароль",
     "passwordbox-continue": "Продовжити",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "Пароль занадто короткий",
     "passwordbox-password-skip": "Наразі пропустити",
     "passwordbox-reset-password": "Скинути за допомогою секретних слів",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "Сума замовлення",
     "payment-info-line-vendor-markup": "Націнка від постачальника",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "Комісія обміну",
     "sign-swap-of-exchange-value": "суми обміну.",
     "sign-swap-total-fees": "Сумарна комісія",
-    "sign-swap-your-bank": "Ваш банк",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "Ваш банк"
 }

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -68,11 +68,6 @@
     "sign-tx-fee": "手续费",
     "sign-tx-cancel-payment": "取消付款",
 
-    "sign-multisig-tx-heading-tx": "Approve Multisig Transaction",
-    "sign-multisig-tx-approving-as": "Approving as",
-    "sign-multisig-tx-with": "with",
-    "sign-multisig-tx-approving-with": "Approving with",
-
     "sign-msg-heading": "签署信息",
     "sign-msg-signer": "签署者",
 
@@ -84,6 +79,7 @@
 
     "passwordbox-enter-password": "输入你的密码",
     "passwordbox-enter-pin": "输入你的PIN码",
+    "passwordbox-swap-authorized": "Swap authorized",
     "passwordbox-repeat-password": "再次输入密码",
     "passwordbox-repeat": "再次输入密码",
     "passwordbox-continue": "继续",
@@ -107,7 +103,6 @@
     "passwordbox-repeat-password-short": "密码太短",
     "passwordbox-password-skip": "现在跳过",
     "passwordbox-reset-password": "使用助记词重置",
-    "passwordbox-connect-account": "Connect your account",
 
     "payment-info-line-order-amount": "订单数量",
     "payment-info-line-vendor-markup": "供应商加密货币加价",
@@ -242,7 +237,5 @@
     "sign-swap-exchange-fee": "交换费用",
     "sign-swap-of-exchange-value": "交换价值",
     "sign-swap-total-fees": "总费用",
-    "sign-swap-your-bank": "你的银行",
-
-    "connect-heading-prefix": "Log in to"
+    "sign-swap-your-bank": "你的银行"
 }


### PR DESCRIPTION
Display a "Swap Authorized" indicator for KYC-enabled swaps.
Additionally, includes a bit of code cleanup and a bug fix in the PasswordBox component before adding this change there.

The current check for the KYC token is very primitive, but good enough for now, because not much harm can be done by providing a fake KYC token (only causes the Keyguard to display the "Swap authorized") and because the swap request can only be sent to the hub by trusted apps.
Eventually, I plan to check the KYC token signature and content.
For this, I want to use https://github.com/panva/jose/, strip it down to only the required parts, translate those to js and potentially put it into a sandbox as we're doing for the multisig rsa lib.
But all that doesn't have to happen before mainnet launch.