### PR TITLE
QrScanner: disable native BarcodeDetector on M1 Macs with Ventura

### DIFF
--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -259,28 +259,31 @@ class QrScanner {
      * @returns {Promise<Worker | BarcodeDetector>}
      */
     static async createQrEngine(workerPath = QrScanner.WORKER_PATH) {
-        const userAgentData = navigator.userAgentData;
-        const useNativeBarcodeDetector = 'BarcodeDetector' in window
+        const supportsBarcodeDetector = 'BarcodeDetector' in window
             && BarcodeDetector.getSupportedFormats
-            && (await BarcodeDetector.getSupportedFormats()).includes('qr_code')
-            // On Macs with an M1 processor and macOS Ventura (macOS version 13), the BarcodeDetector is broken in
-            // Chromium based browsers, regardless of the version. For that constellation, the BarcodeDetector does not
-            // error but does not detect QR codes. Macs without an M1 or before Ventura are fine.
-            // See issue qr-scanner/#209 and https://bugs.chromium.org/p/chromium/issues/detail?id=1382442
-            // TODO update this once the issue in macOS is fixed
-            && !(userAgentData // userAgentData is supported by all Chromium browsers
-                && /macOS/i.test(userAgentData.platform)
-                && userAgentData.brands.some(({ brand }) => /Chromium/i.test(brand))
-                // Check this last as getHighEntropyValues can theoretically trigger a browser prompt.
-                // If browser or user refused to return the requested values, disable the BarcodeDetector, to be safe.
-                && await userAgentData.getHighEntropyValues(['architecture', 'platformVersion'])
-                    .then(({ architecture, platformVersion }) => /arm/i.test(architecture || 'arm')
-                        && Number.parseInt(platformVersion || '13', 10) >= 13)
-                    .catch(() => true)
-            );
-        return useNativeBarcodeDetector
-            ? new BarcodeDetector({ formats: ['qr_code'] })
-            : new Worker(workerPath);
+            && (await BarcodeDetector.getSupportedFormats()).includes('qr_code');
+
+        if (!supportsBarcodeDetector) return new Worker(workerPath);
+
+        // On Macs with an M1/M2 processor and macOS Ventura (macOS version 13), the BarcodeDetector is broken in
+        // Chromium based browsers, regardless of the version. For that constellation, the BarcodeDetector does not
+        // error but does not detect QR codes. Macs without an M1/M2 or before Ventura are fine.
+        // See issue qr-scanner/#209 and https://bugs.chromium.org/p/chromium/issues/detail?id=1382442
+        // TODO update this once the issue in macOS is fixed
+        const userAgentData = navigator.userAgentData;
+        const isChromiumOnMacWithArmVentura = userAgentData // all Chromium browsers support userAgentData
+            && userAgentData.brands.some(({ brand }) => /Chromium/i.test(brand))
+            && /mac ?OS/i.test(userAgentData.platform)
+            // Does it have an ARM chip (e.g. M1/M2) and Ventura? Check this last as getHighEntropyValues can
+            // theoretically trigger a browser prompt, although no browser currently does seem to show one.
+            // If browser or user refused to return the requested values, assume broken ARM Ventura, to be safe.
+            && await userAgentData.getHighEntropyValues(['architecture', 'platformVersion'])
+                .then(({ architecture, platformVersion }) => /arm/i.test(architecture || 'arm')
+                    && Number.parseInt(platformVersion || '13', 10) >= /* Ventura */ 13)
+                .catch(() => true);
+        if (isChromiumOnMacWithArmVentura) return new Worker(workerPath);
+
+        return new BarcodeDetector({ formats: ['qr_code'] });
     }
 
     _onPlay() {

--- a/src/lib/QrScanner.js
+++ b/src/lib/QrScanner.js
@@ -259,11 +259,28 @@ class QrScanner {
      * @returns {Promise<Worker | BarcodeDetector>}
      */
     static async createQrEngine(workerPath = QrScanner.WORKER_PATH) {
-        if ('BarcodeDetector' in window && (await BarcodeDetector.getSupportedFormats()).includes('qr_code')) {
-            return new BarcodeDetector({ formats: ['qr_code'] });
-        }
-
-        return new Worker(workerPath);
+        const userAgentData = navigator.userAgentData;
+        const useNativeBarcodeDetector = 'BarcodeDetector' in window
+            && BarcodeDetector.getSupportedFormats
+            && (await BarcodeDetector.getSupportedFormats()).includes('qr_code')
+            // On Macs with an M1 processor and macOS Ventura (macOS version 13), the BarcodeDetector is broken in
+            // Chromium based browsers, regardless of the version. For that constellation, the BarcodeDetector does not
+            // error but does not detect QR codes. Macs without an M1 or before Ventura are fine.
+            // See issue qr-scanner/#209 and https://bugs.chromium.org/p/chromium/issues/detail?id=1382442
+            // TODO update this once the issue in macOS is fixed
+            && !(userAgentData // userAgentData is supported by all Chromium browsers
+                && /macOS/i.test(userAgentData.platform)
+                && userAgentData.brands.some(({ brand }) => /Chromium/i.test(brand))
+                // Check this last as getHighEntropyValues can theoretically trigger a browser prompt.
+                // If browser or user refused to return the requested values, disable the BarcodeDetector, to be safe.
+                && await userAgentData.getHighEntropyValues(['architecture', 'platformVersion'])
+                    .then(({ architecture, platformVersion }) => /arm/i.test(architecture || 'arm')
+                        && Number.parseInt(platformVersion || '13', 10) >= 13)
+                    .catch(() => true)
+            );
+        return useNativeBarcodeDetector
+            ? new BarcodeDetector({ formats: ['qr_code'] })
+            : new Worker(workerPath);
     }
 
     _onPlay() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
     "types/MessagePrefix.d.ts",
     "types/BarcodeScanner.d.ts",
     "types/BitcoinJS.d.ts",
+    "types/UserAgentClientHints.d.ts",
     "src/**/*.js",
     "tests/**/*.js"
   ],

--- a/types/UserAgentClientHints.d.ts
+++ b/types/UserAgentClientHints.d.ts
@@ -1,0 +1,14 @@
+// simplified from https://github.com/lukewarlow/user-agent-data-types/blob/master/index.d.ts
+declare interface Navigator {
+    readonly userAgentData?: {
+        readonly platform: string;
+        readonly brands: Array<{
+            readonly brand: string;
+            readonly version: string;
+        }>;
+        getHighEntropyValues(hints: string[]): Promise<{
+            readonly architecture?: string;
+            readonly platformVersion?: string;
+        }>;
+    };
+}


### PR DESCRIPTION
On Macs with an M1 processor and macOS Ventura (macOS version 13), the BarcodeDetector is broken in Chromium based browsers as of version 107. For that constellation, the BarcodeDetector does not error but does not detect QR codes. Macs without an M1 or before Ventura and Chromium browsers before 107 are fine. See issue nimiq/qr-scanner#209 and https://bugs.chromium.org/p/chromium/issues/detail?id=1382442

The people in the qr-scanner issue claimed that Chromium 106 works fine and the Chromium bug report is also for 107, but it seems like this has not actually been tested on Ventura, so I'm still going to do that on Micha's Mac and adapt the check if required.
Also only after that check I'm going to commit the change also to the qr-scanner repo and release a new package, update the vue-components `QrScanner` and the use in the Wallet.