### PR TITLE
Github actions: manually install Firefox

### DIFF
--- a/.github/workflows/complete-check.yml
+++ b/.github/workflows/complete-check.yml
@@ -13,6 +13,8 @@ jobs:
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+    - name: Install Firefox
+      uses: browser-actions/setup-firefox@v0.0.0
     - name: Install modules
       run: yarn
     - name: Run


### PR DESCRIPTION
`karma start` of `yarn pr` in the Github actions was suddenly complaining that it couldn't find Firefox:
```
Cannot start FirefoxHeadless
Can not find the binary firefox
Please set env variable FIREFOX_BIN
```

In fact, running `sudo find / -iname "firefox"` in the Github action for testing purposes, did only find `/usr/share/bash-completion/completions/firefox` and `/snap/core20/1623/usr/share/bash-completion/completions/firefox` but no Firefox installation.
Maybe Firefox was part of the image `ubuntu-latest` previously, but is not anymore?

For this reason, Firefox is now manually installed with `browser-actions/setup-firefox` which I whitelisted in the Actions permissions in the Keyguard's settings. I gave it a quick review for whether it's doing any shady stuff, just to be extra sure, but it looks all good, and I believe there's also not much damage to be done in the Github Actions anyways.