### PR TITLE
Safari sessionStorage partitioning fix

### DIFF
--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -148,9 +148,13 @@ export class KeyguardClient {
         return this._iframeRequest<EmptyRequest, SimpleResult>(KeyguardCommand.HAS_KEYS);
     }
 
-    public async deriveAddresses(keyId: string, paths: string[]): Promise<DerivedAddress[]> {
+    public async deriveAddresses(
+        keyId: string,
+        paths: string[],
+        tmpCookieEncryptionKey?: Uint8Array,
+    ): Promise<DerivedAddress[]> {
         return this._iframeRequest<DeriveAddressesRequest, DerivedAddress[]>
-            (KeyguardCommand.DERIVE_ADDRESSES, { keyId, paths });
+            (KeyguardCommand.DERIVE_ADDRESSES, { keyId, paths, tmpCookieEncryptionKey });
     }
 
     public async releaseKey(keyId: string, shouldBeRemoved = false): Promise<SimpleResult> {

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -25,6 +25,7 @@ export type SingleKeyResult = {
     fileExported: boolean;
     wordsExported: boolean;
     bitcoinXPub?: string;
+    tmpCookieEncryptionKey?: Uint8Array;
 };
 
 export type TransactionInfo = {
@@ -99,6 +100,7 @@ export type DeriveAddressRequest = SimpleRequest & {
 export type DeriveAddressesRequest = {
     keyId: string,
     paths: string[],
+    tmpCookieEncryptionKey?: Uint8Array,
 };
 
 export type EmptyRequest = null;

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -315,6 +315,7 @@ export type SignSwapRequest = SignSwapRequestStandard | SignSwapRequestSlider;
 
 export type SignSwapResult = SimpleResult & {
     eurPubKey?: string,
+    tmpCookieEncryptionKey?: Uint8Array;
 };
 
 // Used in swap-iframe
@@ -347,6 +348,7 @@ export type SignSwapTransactionsRequest = {
         timeout: number,
         htlcId: string,
     },
+    tmpCookieEncryptionKey?: Uint8Array;
 };
 
 export type SignMessageRequest = SimpleRequest & {

--- a/src/common.js
+++ b/src/common.js
@@ -3,7 +3,6 @@
 /* global Errors */
 /* global Constants */
 /* global CONFIG */
-// /* global BrowserDetection */
 
 /**
  * @callback reject
@@ -13,18 +12,20 @@
 /** @type {Promise<void>?} */
 let __nimiqLoaded = null;
 
-// if ((BrowserDetection.isIOS() || BrowserDetection.isSafari()) && 'serviceWorker' in navigator) {
-//     // Register service worker to strip cookie from requests.
-//     // This file is always called from a ./request/*/ folder, hence the paths.
-//     navigator.serviceWorker.register('../../ServiceWorker.js', {
-//         scope: '../../',
-//     }).then(reg => {
-//         console.debug(`Service worker has been registered for scope: ${reg.scope}`);
-//     }).catch(error => {
-//         console.error('Service worker installation failed');
-//         throw error;
-//     });
-// }
+if ('serviceWorker' in navigator) {
+    // Register service worker to strip cookie from requests.
+    // This is on a best-effort basis. Cookies might still be sent to the server, if the service worker is not activated
+    // yet or the user disables Javascript.
+    // This file is always called from a ./request/*/ folder, hence the paths.
+    navigator.serviceWorker.register('../../ServiceWorker.js', {
+        scope: '../../',
+    }).then(reg => {
+        console.debug(`Service worker has been registered for scope: ${reg.scope}`);
+    }).catch(error => {
+        console.error('Service worker installation failed');
+        throw error;
+    });
+}
 
 /**
  * Singleton promise

--- a/src/config/config.local.js
+++ b/src/config/config.local.js
@@ -2,8 +2,10 @@
 
 // We want to only allow this config file in dev environments. Supporting IPs as hostname is nice for debugging e.g.
 // on mobile devices, though. We assume that any keyguard instance hosted in production would be accessed by DNS.
+// Additionally, we whitelist BrowserStack's localhost tunnel bs-local.com for iOS debugging in BrowserStack, see
+// https://www.browserstack.com/docs/live/local-testing/ios-troubleshooting-guide
 const ipRegEx = /^(?!0)(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/;
-if (window.location.hostname !== 'localhost' && !ipRegEx.test(window.location.hostname)) {
+if (!/^(?:localhost|bs-local.com)$/.test(window.location.hostname) && !ipRegEx.test(window.location.hostname)) {
     throw new Error('Using development config is only allowed locally');
 }
 

--- a/src/lib/BrowserDetection.js
+++ b/src/lib/BrowserDetection.js
@@ -15,6 +15,15 @@ class BrowserDetection { // eslint-disable-line no-unused-vars
     }
 
     /**
+     * @returns {number[]}
+     */
+    static safariVersion() {
+        const versionMatch = navigator.userAgent.match(/Version\/(\d+)(?:\.(\d+))?(?:\.(\d+))?.*Safari/);
+        if (!versionMatch) throw new Error('No Safari version detected.');
+        return versionMatch.slice(1).map(part => Number.parseInt(part || '0', 10));
+    }
+
+    /**
      * @returns {boolean}
      */
     static isIOS() {
@@ -27,9 +36,9 @@ class BrowserDetection { // eslint-disable-line no-unused-vars
      */
     static iOSVersion() {
         if (BrowserDetection.isIOS()) {
-            const v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-            if (v) {
-                return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || '0', 10)];
+            const versionMatch = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+            if (versionMatch) {
+                return versionMatch.slice(1).map(part => Number.parseInt(part || '0', 10));
             }
         }
 

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -31,14 +31,14 @@ class CookieJar { // eslint-disable-line no-unused-vars
      * @param {KeyInfo[]} keys
      */
     static fillKeys(keys) {
-        this.writeCookie('k', this._encodeKeysCookie(keys));
+        this.writeCookie(CookieJar.Cookie.KEYS, this._encodeKeysCookie(keys));
     }
 
     /**
      * @returns {KeyInfo[]}
      */
     static eatKeys() {
-        const keysCookie = this.readCookie('k');
+        const keysCookie = this.readCookie(CookieJar.Cookie.KEYS);
         return keysCookie ? this._decodeKeysCookie(keysCookie) : [];
     }
 
@@ -47,7 +47,7 @@ class CookieJar { // eslint-disable-line no-unused-vars
      * @returns {AccountInfo[]}
      */
     static eatDeprecatedAccounts() {
-        const accountsCookie = this.readCookie('accounts');
+        const accountsCookie = this.readCookie(CookieJar.Cookie.DEPRECATED_ACCOUNTS);
         if (accountsCookie) {
             const decoded = decodeURIComponent(accountsCookie);
             const cookieAccounts = JSON.parse(decoded);
@@ -100,3 +100,23 @@ class CookieJar { // eslint-disable-line no-unused-vars
         });
     }
 }
+
+/**
+ * @readonly
+ * @enum { 'lang' | 'k' | 'removeKey' | 'accounts' | 'migrate' }
+ */
+CookieJar.Cookie = {
+    LANGUAGE: /** @type {'lang'} */ ('lang'),
+    KEYS: /** @type {'k'} */ ('k'),
+    REMOVE_KEY: /** @type {'removeKey'} */ ('removeKey'),
+    /**
+     * @deprecated
+     * @type {'accounts'}
+     */
+    DEPRECATED_ACCOUNTS: ('accounts'),
+    /**
+     * @deprecated
+     * @type {'migrate'}
+     */
+    DEPRECATED_MIGRATION_FLAG: ('migrate'),
+};

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -83,6 +83,19 @@ class CookieJar { // eslint-disable-line no-unused-vars
     }
 
     /**
+     * @param {string} name
+     * @param {boolean} [encodeInvalidChars = true]
+     * @returns {string}
+     */
+    static sanitizeCookieName(name, encodeInvalidChars = true) {
+        if (encodeInvalidChars) return name.replace(CookieJar.INVALID_NAME_CHARS_REGEX, c => encodeURIComponent(c));
+        // truncate invalid chars
+        const truncatedName = name.replace(CookieJar.INVALID_NAME_CHARS_REGEX, '');
+        if (!truncatedName) return this.sanitizeCookieName(name, true);
+        return truncatedName;
+    }
+
+    /**
      * @param {KeyInfo[]} keys
      */
     static fillKeys(keys) {
@@ -169,12 +182,13 @@ class CookieJar { // eslint-disable-line no-unused-vars
 
 /**
  * @readonly
- * @enum { 'lang' | 'k' | 'removeKey' | 'accounts' | 'migrate' }
+ * @enum { 'lang' | 'k' | 'removeKey' | 'cs.' | 'accounts' | 'migrate' }
  */
 CookieJar.Cookie = {
     LANGUAGE: /** @type {'lang'} */ ('lang'),
     KEYS: /** @type {'k'} */ ('k'),
     REMOVE_KEY: /** @type {'removeKey'} */ ('removeKey'),
+    NAMESPACE_COOKIE_STORAGE: /** @type {'cs.'} */ ('cs.'), // no other cookies should start with 'cs.'
     /**
      * @deprecated
      * @type {'accounts'}

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -182,14 +182,15 @@ class CookieJar { // eslint-disable-line no-unused-vars
 
 /**
  * @readonly
- * @enum { 'lang' | 'k' | 'removeKey' | 'ssnp' | 'cs.' | 'accounts' | 'migrate' }
+ * @enum { 'lang' | 'k' | 'removeKey' | 'ssnp' | 'cs.' | 'npss.' | 'accounts' | 'migrate' }
  */
 CookieJar.Cookie = {
     LANGUAGE: /** @type {'lang'} */ ('lang'),
     KEYS: /** @type {'k'} */ ('k'),
     REMOVE_KEY: /** @type {'removeKey'} */ ('removeKey'),
     FLAG_SESSION_STORAGE_NOT_PARTITIONED: /** @type {'ssnp'} */ ('ssnp'),
-    NAMESPACE_COOKIE_STORAGE: /** @type {'cs.'} */ ('cs.'), // no other cookies should start with 'cs.'
+    NAMESPACE_COOKIE_STORAGE: /** @type {'cs.'} */ ('cs.'), // no other cookies start with 'cs.'
+    NAMESPACE_NON_PARTITIONED_SESSION_STORAGE: /** @type {'npss.'} */ ('npss.'), // no other cookies start with 'npss.'
     /**
      * @deprecated
      * @type {'accounts'}

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -182,12 +182,13 @@ class CookieJar { // eslint-disable-line no-unused-vars
 
 /**
  * @readonly
- * @enum { 'lang' | 'k' | 'removeKey' | 'cs.' | 'accounts' | 'migrate' }
+ * @enum { 'lang' | 'k' | 'removeKey' | 'ssnp' | 'cs.' | 'accounts' | 'migrate' }
  */
 CookieJar.Cookie = {
     LANGUAGE: /** @type {'lang'} */ ('lang'),
     KEYS: /** @type {'k'} */ ('k'),
     REMOVE_KEY: /** @type {'removeKey'} */ ('removeKey'),
+    FLAG_SESSION_STORAGE_NOT_PARTITIONED: /** @type {'ssnp'} */ ('ssnp'),
     NAMESPACE_COOKIE_STORAGE: /** @type {'cs.'} */ ('cs.'), // no other cookies should start with 'cs.'
     /**
      * @deprecated

--- a/src/lib/CookieStorage.js
+++ b/src/lib/CookieStorage.js
@@ -1,0 +1,305 @@
+/* global Nimiq */
+/* global CookieJar */
+/* global Errors */
+
+/**
+ * @typedef {{isEncrypted: boolean, chunkCount: number, encryptionInitVector?: Uint8Array}} CookieMetadata
+ */
+
+/**
+ * A library for using cookies for storing arbitrary data. The lib automatically takes care of encoding the data into
+ * cookies, taking size and character restrictions of cookies into account. Additionally, data is encrypted by default,
+ * because cookies are sent to the server unless intercepted. The encryption keys should only be handled and passed on
+ * the client side, and not be leaked to the server.
+ *
+ * The CookieStorage can be a viable alternative for cases where other storage types like sessionStorage, localStorage
+ * or indexedDB are partitioned between the Keyguard running in a top-level context and as an iframe, in which case
+ * data set in the top-level context are not accessible in the iframe, and vice-versa. Cookies on the other hand are
+ * shared between these contexts.
+ *
+ * Not to be confused with the browser-native, experimental CookieStore which is a more modern way of plain cookie
+ * access.
+ */
+class CookieStorage {
+    /**
+     * @param {string} name
+     * @param {Uint8Array} data
+     * @param {Uint8Array} [encryptionKey] The encryption key to use. If none is provided, a new one will be created.
+     * @param {number} [maxAge] Time in seconds after which the data gets automatically deleted.
+     * @returns {Promise<Uint8Array | null>} New encryption key, if one was created.
+     */
+    static async set(name, data, encryptionKey, maxAge) {
+        let createdNewKey = false;
+        if (!encryptionKey) {
+            encryptionKey = crypto.getRandomValues(new Uint8Array(CookieStorage.ENCRYPTION_KEY_SIZE));
+            createdNewKey = true;
+        }
+        const encryptionInitVector = crypto.getRandomValues(new Uint8Array(CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE));
+
+        const encryptedData = new Uint8Array(await crypto.subtle.encrypt(
+            /* algorithm */ {
+                name: CookieStorage.ENCRYPTION_ALGORITHM,
+                iv: encryptionInitVector,
+            },
+            await this._importEncryptionKey(encryptionKey),
+            data,
+        ));
+
+        this._writeCookies(name, encryptedData, { encryptionInitVector, maxAge });
+
+        return createdNewKey ? encryptionKey : null;
+    }
+
+    /**
+     * Set a data entry without encrypting it. Because cookies are sent to the server, unless intercepted, unencrypted
+     * cookie data should be considered public. Whenever possible, set encrypted data instead, especially for secret
+     * data or data concerning the user's privacy.
+     * @param {string} name
+     * @param {Uint8Array} data
+     * @param {number} [maxAge] Time in seconds after which the data gets automatically deleted.
+     */
+    static setPublicUnencrypted(name, data, maxAge) {
+        this._writeCookies(name, data, { maxAge });
+    }
+
+    /**
+     * @param {string} name
+     * @param {Uint8Array} [encryptionKey] Must be passed for encrypted entries.
+     * @returns {Promise<Uint8Array | null>}
+     */
+    static async get(name, encryptionKey) {
+        const dataAndMetadata = this._readCookies(name);
+        if (!dataAndMetadata) return null;
+        const { data, metadata } = dataAndMetadata;
+        if (!metadata.isEncrypted) return data;
+        if (!encryptionKey) throw new Errors.KeyguardError('Encryption key must be passed for getting encrypted data.');
+        return new Uint8Array(await crypto.subtle.decrypt(
+            /* algorithm */ {
+                name: CookieStorage.ENCRYPTION_ALGORITHM,
+                iv: metadata.encryptionInitVector,
+            },
+            await this._importEncryptionKey(encryptionKey),
+            data,
+        ));
+    }
+
+    /**
+     * @param {string} name
+     */
+    static delete(name) {
+        const metadata = this._getMetaData(name);
+        if (!metadata) return; // Data entry does not exist.
+        for (let chunk = 0; chunk < metadata.chunkCount; ++chunk) {
+            CookieJar.deleteCookie(this._getChunkCookieName(name, chunk));
+        }
+    }
+
+    /**
+     * @param {string} name
+     * @returns {boolean}
+     */
+    static has(name) {
+        return !!CookieJar.readCookie(this._getChunkCookieName(name, 0));
+    }
+
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @param {string} name
+     * @param {Uint8Array} data
+     * @param {{encryptionInitVector?: Uint8Array, maxAge?: number}} [options]
+     * @private
+     */
+    static _writeCookies(name, data, options = {}) {
+        const { encryptionInitVector, maxAge } = options;
+        const previousMetadata = this._getMetaData(name);
+        const previousChunkCount = previousMetadata ? previousMetadata.chunkCount : 0;
+
+        const metadata = {
+            chunkCount: 1, // preliminary
+            isEncrypted: !!encryptionInitVector,
+            // Note: the encryption init vector does not need to be secret, and can be stored in plain text in the
+            // cookie, see https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#parameters.
+            encryptionInitVector,
+        };
+        let encodedMetadata = this._encodeMetadata(metadata);
+        const completeData = new Uint8Array(encodedMetadata.byteLength + data.byteLength);
+        completeData.set(encodedMetadata);
+        completeData.set(data, encodedMetadata.length);
+
+        let chunkCount = 0;
+        /** @type {string | null} */
+        let remainingDataToWrite = this._toBase64UrlWithoutPadding(completeData);
+        do {
+            const chunkCookieName = this._getChunkCookieName(name, chunkCount);
+            remainingDataToWrite = CookieJar.writeCookie(chunkCookieName, remainingDataToWrite, maxAge);
+            chunkCount += 1;
+        } while (remainingDataToWrite);
+
+        if (chunkCount > metadata.chunkCount) {
+            // We have more than one chunk and have to update the preliminary chunkCount.
+            // Overwrite the encoded metadata and the first chunk cookie. The remaining data does not change or shift.
+            metadata.chunkCount = chunkCount;
+            encodedMetadata = this._encodeMetadata(metadata);
+            completeData.set(encodedMetadata);
+            const firstChunkCookieName = this._getChunkCookieName(name, 0);
+            CookieJar.writeCookie(firstChunkCookieName, this._toBase64UrlWithoutPadding(completeData), maxAge);
+        }
+
+        // Delete old excess cookies.
+        for (let chunkToDelete = chunkCount; chunkToDelete < previousChunkCount; ++chunkToDelete) {
+            CookieJar.deleteCookie(this._getChunkCookieName(name, chunkToDelete));
+        }
+    }
+
+    /**
+     * @param {string} name
+     * @returns {{metadata: CookieMetadata, data: Uint8Array} | null}
+     * @private
+     */
+    static _readCookies(name) {
+        const metadata = this._getMetaData(name);
+        if (!metadata) return null;
+
+        let cookieDataBase64Url = '';
+        for (let chunk = 0; chunk < metadata.chunkCount; ++chunk) {
+            const chunkData = CookieJar.readCookie(this._getChunkCookieName(name, chunk));
+            if (!chunkData) return null;
+            cookieDataBase64Url += chunkData;
+        }
+
+        const data = Nimiq.BufferUtils.fromBase64Url(cookieDataBase64Url)
+            .subarray(this._calculateEncodedMetadataSize(metadata));
+        return { data, metadata };
+    }
+
+    /**
+     * @param {string} name
+     * @returns {CookieMetadata | null}
+     * @private
+     */
+    static _getMetaData(name) {
+        const firstChunk = CookieJar.readCookie(this._getChunkCookieName(name, 0));
+        if (!firstChunk) return null;
+        // Read enough base64 data to include the longest possible metadata, if the cookie is long enough.
+        return this._decodeMetadata(Nimiq.BufferUtils.fromBase64Url(firstChunk.substring(
+            0,
+            CookieStorage.MAX_ENCODED_METADATA_SIZE_BASE64,
+        )));
+    }
+
+    /* eslint-disable no-bitwise */
+    /**
+     * @param {Uint8Array} encodedMetadata
+     * @returns {CookieMetadata}
+     * @private
+     */
+    static _decodeMetadata(encodedMetadata) {
+        if (!encodedMetadata.byteLength) throw new Errors.KeyguardError('Invalid CookieStorage metadata.');
+        const isEncrypted = !!(encodedMetadata[0] & 0b1);
+        const chunkCount = encodedMetadata[0] >> 1;
+        /** @type {Uint8Array | undefined} */
+        let encryptionInitVector;
+
+        if (isEncrypted) {
+            encryptionInitVector = encodedMetadata.subarray(1, 1 + CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE);
+            if (encryptionInitVector.byteLength !== CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE) {
+                // not enough data provided
+                throw new Errors.KeyguardError('Invalid CookieStorage metadata.');
+            }
+        }
+
+        return {
+            isEncrypted,
+            chunkCount,
+            encryptionInitVector,
+        };
+    }
+
+    /**
+     * @param {CookieMetadata} metadata
+     * @returns {Uint8Array}
+     * @private
+     */
+    static _encodeMetadata(metadata) {
+        const encryptionInitVectorSize = metadata.encryptionInitVector ? metadata.encryptionInitVector.byteLength : 0;
+        if (metadata.chunkCount > 127
+            || (metadata.isEncrypted && !metadata.encryptionInitVector)
+            || (metadata.encryptionInitVector && encryptionInitVectorSize !== CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE)
+        ) throw new Errors.KeyguardError('Invalid CookieStorage metadata.');
+        const encodedMetadata = new Uint8Array(this._calculateEncodedMetadataSize(metadata));
+        encodedMetadata[0] = (metadata.chunkCount << 1) | (metadata.isEncrypted ? 0b1 : 0b0);
+
+        if (metadata.encryptionInitVector) {
+            encodedMetadata.set(metadata.encryptionInitVector, 1);
+        }
+        return encodedMetadata;
+    }
+    /* eslint-enable no-bitwise */
+
+    /**
+     * @param {CookieMetadata} metadata
+     * @returns {number}
+     * @private
+     */
+    static _calculateEncodedMetadataSize(metadata) {
+        return /* encoded isEncrypted flag + chunkCount */ 1
+            + (metadata.isEncrypted && metadata.encryptionInitVector ? metadata.encryptionInitVector.byteLength : 0);
+    }
+
+    /**
+     * @param {Uint8Array} data
+     * @returns {string}
+     * @private
+     */
+    static _toBase64UrlWithoutPadding(data) {
+        return Nimiq.BufferUtils.toBase64Url(data).replace(/\.+$/, ''); // remove trailing padding
+    }
+
+    /**
+     * @param {string} name
+     * @param {number} chunk
+     * @returns {string}
+     * @private
+     */
+    static _getChunkCookieName(name, chunk) {
+        name = CookieJar.sanitizeCookieName(name, /* encodeInvalidChars */ false);
+        return `${CookieJar.Cookie.NAMESPACE_COOKIE_STORAGE}${name}${chunk !== 0 ? `${chunk.toString(36)}` : ''}`;
+    }
+
+    /**
+     * @param {Uint8Array} encryptionKey
+     * @returns {Promise<CryptoKey>}
+     * @private
+     */
+    static async _importEncryptionKey(encryptionKey) {
+        if (encryptionKey.byteLength !== CookieStorage.ENCRYPTION_KEY_SIZE) {
+            throw new Errors.KeyguardError('Invalid encryption key.');
+        }
+        return crypto.subtle.importKey(
+            /* format */ 'raw',
+            encryptionKey,
+            /* algorithm */ CookieStorage.ENCRYPTION_ALGORITHM,
+            /* extractable */ false,
+            /* key usages */ ['encrypt', 'decrypt'],
+        );
+    }
+}
+// Symmetric AES encryption; use GCM variant because it provides built-in ciphertext authentication, see
+// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms. For us, this means it
+// automatically checks whether the decryption key passed matches the ciphertext to be decrypted, and we don't have to
+// check the decrypted content with an integrity hash ourselves. For this purpose, an authentication tag of 128 bit is
+// appended to the ciphertext, see https://w3c.github.io/webcrypto/#aes-gcm-operations.
+CookieStorage.ENCRYPTION_ALGORITHM = 'AES-GCM';
+// 32 bytes; although AES-GCM's block size is 128 bit, the key size can be longer than that, see section 5.1 in
+// https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+CookieStorage.ENCRYPTION_KEY_SIZE = 256 / 8;
+// 12 bytes; as recommended in 5.2.1.1 of https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE = 96 / 8;
+// @ts-ignore _calculateEncodedMetadataSize is private
+CookieStorage.MAX_ENCODED_METADATA_SIZE = CookieStorage._calculateEncodedMetadataSize({
+    isEncrypted: true,
+    chunkCount: 1,
+    encryptionInitVector: new Uint8Array(CookieStorage.ENCRYPTION_INIT_VECTOR_SIZE),
+});
+// Our base64 encoding doesn't have to take padding into account because we represent base64 without padding.
+CookieStorage.MAX_ENCODED_METADATA_SIZE_BASE64 = Math.ceil(CookieStorage.MAX_ENCODED_METADATA_SIZE * 4 / 3);

--- a/src/lib/CookieStorage.js
+++ b/src/lib/CookieStorage.js
@@ -9,8 +9,10 @@
 /**
  * A library for using cookies for storing arbitrary data. The lib automatically takes care of encoding the data into
  * cookies, taking size and character restrictions of cookies into account. Additionally, data is encrypted by default,
- * because cookies are sent to the server unless intercepted. The encryption keys should only be handled and passed on
- * the client side, and not be leaked to the server.
+ * because cookies are sent to the server unless intercepted, which the Keyguard does via a cookie stripping service
+ * worker. However, there might still be situations in which the cookies are sent to the server, for example if the user
+ * turns Javascript off or the service worker is not activated yet. The encryption keys should only be handled and
+ * passed on the client side, and not be leaked to the server.
  *
  * The CookieStorage can be a viable alternative for cases where other storage types like sessionStorage, localStorage
  * or indexedDB are partitioned between the Keyguard running in a top-level context and as an iframe, in which case
@@ -55,9 +57,10 @@ class CookieStorage {
     }
 
     /**
-     * Set a data entry without encrypting it. Because cookies are sent to the server, unless intercepted, unencrypted
-     * cookie data should be considered public. Whenever possible, set encrypted data instead, especially for secret
-     * data or data concerning the user's privacy.
+     * Set a data entry without encrypting it. Although the Keyguard takes measures on a best-effort basis to avoid that
+     * cookies are sent to the server via a cookie-stripping service worker, any unencrypted cookie data should still be
+     * considered public. Whenever possible, set encrypted data instead, especially for secret data or data concerning
+     * the user's privacy.
      * @param {string} name
      * @param {Uint8Array} data
      * @param {Object} [options]

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -29,7 +29,7 @@ class I18n { // eslint-disable-line no-unused-vars
      * @returns {string} The detected language set in the 'lang' cookie. Fallback to the browser language.
      */
     static detectLanguage() {
-        const langCookie = CookieJar.readCookie('lang');
+        const langCookie = CookieJar.readCookie(CookieJar.Cookie.LANGUAGE);
         const lang = langCookie ? decodeURIComponent(langCookie) : navigator.language.split('-')[0];
         return I18n.getClosestSupportedLanguage(lang);
     }

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -1,5 +1,6 @@
 /* global TRANSLATIONS */ // eslint-disable-line no-unused-vars
 /* global Nimiq */
+/* global CookieJar */
 
 /**
  * @typedef {{[language: string]: {[id: string]: string}}} dict
@@ -28,10 +29,8 @@ class I18n { // eslint-disable-line no-unused-vars
      * @returns {string} The detected language set in the 'lang' cookie. Fallback to the browser language.
      */
     static detectLanguage() {
-        const cookieMatch = document.cookie.match(new RegExp('(^| )lang=([^;]+)'));
-        const cookieLang = cookieMatch && decodeURIComponent(cookieMatch[2]);
-
-        const lang = cookieLang || navigator.language.split('-')[0];
+        const langCookie = CookieJar.readCookie('lang');
+        const lang = langCookie ? decodeURIComponent(langCookie) : navigator.language.split('-')[0];
         return I18n.getClosestSupportedLanguage(lang);
     }
 

--- a/src/lib/NonPartitionedSessionStorage.js
+++ b/src/lib/NonPartitionedSessionStorage.js
@@ -1,0 +1,137 @@
+/* global Nimiq */
+/* global CookieStorage */
+/* global BrowserDetection */
+
+class NonPartitionedSessionStorage {
+    /**
+     * @param {string} name
+     * @param {Uint8Array} data
+     * @param {Uint8Array} [encryptionKey]
+     * @returns {Promise<Uint8Array | null>} New CookieStorage encryption key, if one was created.
+     */
+    static async set(name, data, encryptionKey) {
+        const isSessionStoragePartitioned = this.isSessionStoragePartitioned();
+        // Delete old data entries that might not have been migrated over yet.
+        this.delete(name);
+
+        if (isSessionStoragePartitioned) {
+            // Use CookieStorage. We currently only support encrypted CookieStorage entries, to encourage encryption.
+            return CookieStorage.set(name, data, encryptionKey, NonPartitionedSessionStorage.COOKIE_MAX_AGE);
+        }
+
+        sessionStorage.setItem(name, Nimiq.BufferUtils.toBase64(data));
+        return null;
+    }
+
+    /**
+     * @param {string} name
+     * @param {Uint8Array} [encryptionKey]
+     * @returns {Promise<Uint8Array | { data: Uint8Array, newEncryptionKey: Uint8Array } | null>}
+     */
+    static async get(name, encryptionKey) {
+        /** @type {Uint8Array | null} */
+        const cookieStorageData = CookieStorage.has(name)
+            // We currently only support encrypted CookieStorage entries, to encourage encryption. Throws for wrong key.
+            ? await CookieStorage.get(name, encryptionKey)
+            : null;
+        const sessionStorageDataBase64 = sessionStorage.getItem(name);
+        const sessionStorageData = sessionStorageDataBase64
+            ? Nimiq.BufferUtils.fromBase64(sessionStorageDataBase64)
+            : null;
+
+        // Note that with sessionStorage we can expect migrations to work reasonable well because it only lives within
+        // the same tab, i.e. within a well-controlled environment where we can manually make sure that the
+        // encryptionKeys are available for the lifetime of the tab. Migrating longer-lived values, for example in
+        // localStorage, would require additional care of persisting the shared encryption keys in both, the top-level
+        // and iframe contexts, to be available at any time.
+        if (this.isSessionStoragePartitioned()) {
+            if (sessionStorageData && !cookieStorageData) {
+                // sessionStorage is detected/assumed to be partitioned now but was not previously. Migrate data. Note
+                // that if sessionStorage is partitioned, this will effectively only migrate data written in the same
+                // context, i.e. in top-level contexts only the sessionStore data previously written in top-level
+                // windows can be migrated and in iframes only the data written in iframes.
+                const newEncryptionKey = await CookieStorage.set(
+                    name,
+                    sessionStorageData,
+                    encryptionKey,
+                    NonPartitionedSessionStorage.COOKIE_MAX_AGE,
+                );
+                sessionStorage.removeItem(name);
+                return newEncryptionKey
+                    ? { data: sessionStorageData, newEncryptionKey }
+                    : sessionStorageData;
+            }
+            return cookieStorageData;
+        } else { // eslint-disable-line no-else-return
+            if (!sessionStorageData && cookieStorageData) {
+                // sessionStorage is not detected/assumed to be partitioned now but was previously. Migrate data.
+                sessionStorage.setItem(name, Nimiq.BufferUtils.toBase64(cookieStorageData));
+                CookieStorage.delete(name);
+                return cookieStorageData;
+            }
+            return sessionStorageData;
+        }
+    }
+
+    /**
+     * @param {string} name
+     */
+    static delete(name) {
+        sessionStorage.removeItem(name);
+        CookieStorage.delete(name);
+    }
+
+    /**
+     * @param {string} name
+     * @returns {boolean}
+     */
+    static has(name) {
+        return !!sessionStorage.getItem(name) || CookieStorage.has(name);
+    }
+
+    /**
+     * Is the sessionStorage partitioned between Keyguard top-level, first-party windows and third-party iframe embedded
+     * in the Hub?
+     * @returns {boolean}
+     */
+    static isSessionStoragePartitioned() {
+        if (!this.hasSessionStorageAccess()) {
+            // sessionStorage is not even accessible. Report as being partitioned to avoid using it.
+            return true;
+        }
+        // Safari introduced sessionStorage partitioning with version 16.1., which is currently based on the origin of
+        // the top level window, but might be changed to be based on the registrable domain or eTLD+1 (e.g. nimiq.com
+        // instead of hub.nimiq.com). If this change happens, the Keyguard's sessionStorage would not be partitioned
+        // anymore between the Keyguard top-level and Keyguard iframe within the Hub, because the Keyguard and Hub live
+        // on the same eTLD+1. This issue is tracked here: https://bugs.webkit.org/show_bug.cgi?id=247565
+        if (!BrowserDetection.isSafari()) return false;
+        const safariVersion = BrowserDetection.safariVersion();
+        return safariVersion[0] >= 16 && safariVersion[1] >= 1;
+    }
+
+    static hasSessionStorageAccess() {
+        if (NonPartitionedSessionStorage._hasSessionStorageAccess !== undefined) {
+            return NonPartitionedSessionStorage._hasSessionStorageAccess;
+        }
+        try {
+            sessionStorage.setItem('_test', 'write-access');
+            const stored = sessionStorage.getItem('_test');
+            if (stored !== 'write-access') throw new Error();
+            sessionStorage.removeItem('_test');
+            NonPartitionedSessionStorage._hasSessionStorageAccess = true;
+        } catch (e) {
+            NonPartitionedSessionStorage._hasSessionStorageAccess = false;
+        }
+        return NonPartitionedSessionStorage._hasSessionStorageAccess;
+    }
+
+    static isIframe() {
+        return window.top !== window;
+    }
+}
+// 7 minutes to simulate an ephemeral storage, similar to sessionStorage. Note that we set a max age and don't simply
+// use session cookies because session cookies live until the browser is closed, or even longer if the browser is
+// configured to persist sessions.
+NonPartitionedSessionStorage.COOKIE_MAX_AGE = 7 * 60; // 7 minutes; in seconds
+/** @type {boolean | undefined} */
+NonPartitionedSessionStorage._hasSessionStorageAccess = undefined;

--- a/src/lib/RpcServer.es.js
+++ b/src/lib/RpcServer.es.js
@@ -247,7 +247,7 @@ class RpcServer { // eslint-disable-line no-unused-vars
             return this._receive(urlRequest);
         }
 
-        // Check for a stored request referenced by a URL 'id' parameter
+        // Check for a stored request referenced by a URL 'rpcId' parameter
         const searchParams = new URLSearchParams(window.location.search);
         if (searchParams.has(UrlRpcEncoder.URL_SEARCHPARAM_NAME)) {
             const storedRequest = window.sessionStorage.getItem(
@@ -292,6 +292,9 @@ class RpcServer { // eslint-disable-line no-unused-vars
             console.debug('RpcServer ACCEPT', state.data);
 
             if (persistMessage) {
+                // We don't have to take storage partitioning between top-level, first-party contexts and iframe,
+                // third-party contexts into account here because the request doesn't have to be shared between
+                // top-level windows and iframes.
                 sessionStorage.setItem(`request-${state.data.id}`, JsonUtils.stringify(state.toRequestObject()));
             }
 

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -90,11 +90,11 @@ class TopLevelApi extends RequestParser {
              */
             if (TopLevelApi._hasRemoveKey()) {
                 // eat
-                const match = document.cookie.match(new RegExp('removeKey=([^;]+)'));
-                if (match && match[1]) {
+                const removeKeyCookie = CookieJar.readCookie('removeKey');
+                if (removeKeyCookie) {
                     try {
                         /** @type {string[]} */
-                        const removeKeyArray = JSON.parse(match[1]);
+                        const removeKeyArray = JSON.parse(removeKeyCookie);
                         await Promise.all(removeKeyArray.map(keyId => KeyStore.instance.remove(keyId)));
                     } catch (e) {
                         this._reject(e);
@@ -213,7 +213,7 @@ class TopLevelApi extends RequestParser {
         // Keys might have changed, so update cookie for iOS and Safari users
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             const keys = await KeyStore.instance.list();
-            CookieJar.fill(keys);
+            CookieJar.fillKeys(keys);
         }
 
         this._resolve(result);
@@ -328,8 +328,7 @@ class TopLevelApi extends RequestParser {
      * @private
      */
     static _hasMigrateFlag() {
-        const match = document.cookie.match(new RegExp('migrate=([^;]+)'));
-        return !!match && match[1] === '1';
+        return CookieJar.readCookie('migrate') === '1';
     }
 
     /**
@@ -337,8 +336,7 @@ class TopLevelApi extends RequestParser {
      * @private
      */
     static _hasRemoveKey() {
-        const match = document.cookie.match(new RegExp('removeKey=([^;]+)'));
-        return !!match && match[1] !== '';
+        return !!CookieJar.readCookie('removeKey');
     }
 
     /**

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -90,7 +90,7 @@ class TopLevelApi extends RequestParser {
              */
             if (TopLevelApi._hasRemoveKey()) {
                 // eat
-                const removeKeyCookie = CookieJar.readCookie('removeKey');
+                const removeKeyCookie = CookieJar.readCookie(CookieJar.Cookie.REMOVE_KEY);
                 if (removeKeyCookie) {
                     try {
                         /** @type {string[]} */
@@ -328,7 +328,7 @@ class TopLevelApi extends RequestParser {
      * @private
      */
     static _hasMigrateFlag() {
-        return CookieJar.readCookie('migrate') === '1';
+        return CookieJar.readCookie(CookieJar.Cookie.DEPRECATED_MIGRATION_FLAG) === '1';
     }
 
     /**
@@ -336,7 +336,7 @@ class TopLevelApi extends RequestParser {
      * @private
      */
     static _hasRemoveKey() {
-        return !!CookieJar.readCookie('removeKey');
+        return !!CookieJar.readCookie(CookieJar.Cookie.REMOVE_KEY);
     }
 
     /**

--- a/src/request/iframe/IFrameApi.js
+++ b/src/request/iframe/IFrameApi.js
@@ -55,14 +55,8 @@ class IFrameApi {
     async releaseKey(state, request) {
         if (request.shouldBeRemoved && sessionStorage.getItem(IFrameApi.SESSION_STORAGE_KEY_PREFIX + request.keyId)) {
             if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
-                const match = document.cookie.match(new RegExp('removeKey=([^;]+)'));
-                /** @type {string[]} */
-                let removeKeyArray;
-                if (match && match[1]) {
-                    removeKeyArray = JSON.parse(match[1]);
-                } else {
-                    removeKeyArray = [];
-                }
+                const removeKeyCookie = CookieJar.readCookie('removeKey');
+                const removeKeyArray = removeKeyCookie ? JSON.parse(removeKeyCookie) : [];
                 removeKeyArray.push(request.keyId);
                 CookieJar.writeCookie('removeKey', JSON.stringify(removeKeyArray));
             } else {
@@ -128,7 +122,7 @@ class IFrameApi {
      */
     async _getAccounts() {
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
-            return CookieJar.eatDeprecated();
+            return CookieJar.eatDeprecatedAccounts();
         }
 
         return AccountStore.instance.list();
@@ -139,7 +133,7 @@ class IFrameApi {
      */
     async _getKeys() {
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
-            return CookieJar.eat();
+            return CookieJar.eatKeys();
         }
 
         return KeyStore.instance.list();

--- a/src/request/iframe/IFrameApi.js
+++ b/src/request/iframe/IFrameApi.js
@@ -55,10 +55,10 @@ class IFrameApi {
     async releaseKey(state, request) {
         if (request.shouldBeRemoved && sessionStorage.getItem(IFrameApi.SESSION_STORAGE_KEY_PREFIX + request.keyId)) {
             if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
-                const removeKeyCookie = CookieJar.readCookie('removeKey');
+                const removeKeyCookie = CookieJar.readCookie(CookieJar.Cookie.REMOVE_KEY);
                 const removeKeyArray = removeKeyCookie ? JSON.parse(removeKeyCookie) : [];
                 removeKeyArray.push(request.keyId);
-                CookieJar.writeCookie('removeKey', JSON.stringify(removeKeyArray));
+                CookieJar.writeCookie(CookieJar.Cookie.REMOVE_KEY, JSON.stringify(removeKeyArray));
             } else {
                 await KeyStore.instance.remove(request.keyId);
             }
@@ -106,7 +106,7 @@ class IFrameApi {
          */
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             // Set migrate flag cookie
-            CookieJar.writeCookie('migrate', '1');
+            CookieJar.writeCookie(CookieJar.Cookie.DEPRECATED_MIGRATION_FLAG, '1');
             return { success: true };
         }
 

--- a/src/request/iframe/index.html
+++ b/src/request/iframe/index.html
@@ -23,6 +23,8 @@
         <script defer bundle-common src="../../lib/ErrorConstants.js"></script>
         <script defer bundle-common src="../../lib/SignMessageConstants.js"></script>
         <script defer bundle-common src="../../lib/CookieJar.js"></script>
+        <script defer bundle-common src="../../lib/CookieStorage.js"></script>
+        <script defer bundle-common src="../../lib/NonPartitionedSessionStorage.js"></script>
         <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
         <script defer bundle-common src="../../lib/AccountStore.js"></script>
         <script defer bundle-common src="../../common.js"></script>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -23,6 +23,8 @@
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
     <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/CookieStorage.js"></script>
+    <script defer bundle-common src="../../lib/NonPartitionedSessionStorage.js"></script>
     <script defer bundle-common src="../../lib/Errors.js"></script>
     <script defer bundle-common src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-common src="../../lib/SignMessageConstants.js"></script>

--- a/src/request/sign-swap/SignSwapApi.js
+++ b/src/request/sign-swap/SignSwapApi.js
@@ -15,15 +15,6 @@ class SignSwapApi extends BitcoinRequestParserMixin(TopLevelApi) {
             throw new Errors.InvalidRequestError('request is required');
         }
 
-        try {
-            sessionStorage.setItem('_test', 'write-access');
-            const stored = sessionStorage.getItem('_test');
-            if (stored !== 'write-access') throw new Error();
-            sessionStorage.removeItem('_test');
-        } catch (e) {
-            throw new Error('Cannot access browser storage because of privacy settings');
-        }
-
         /** @type {Parsed<KeyguardRequest.SignSwapRequest>} */
         const parsedRequest = {};
         parsedRequest.appName = this.parseAppName(request.appName);

--- a/src/request/sign-swap/index.html
+++ b/src/request/sign-swap/index.html
@@ -23,6 +23,8 @@
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieStorage.js"></script>
+    <script defer bundle-common src="../../lib/NonPartitionedSessionStorage.js"></script>
     <script defer bundle-common src="../../lib/Errors.js"></script>
     <script defer bundle-common src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-common src="../../lib/SignMessageConstants.js"></script>

--- a/src/request/swap-iframe/index.html
+++ b/src/request/swap-iframe/index.html
@@ -19,6 +19,8 @@
         <script defer bundle-common src="../../lib/KeyStore.js"></script>
         <script defer bundle-common src="../../lib/Key.js"></script>
         <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+        <script defer bundle-common src="../../lib/CookieStorage.js"></script>
+        <script defer bundle-common src="../../lib/NonPartitionedSessionStorage.js"></script>
         <script defer bundle-common src="../../lib/Errors.js"></script>
         <script defer bundle-common src="../../lib/ErrorConstants.js"></script>
         <script defer bundle-common src="../../lib/SignMessageConstants.js"></script>

--- a/tests/DummyData.spec.js
+++ b/tests/DummyData.spec.js
@@ -146,7 +146,7 @@ const deprecatedAccount2Keys = () => [
     new Key(secrets[1], false)
 ];
 
-const keyInfoCookieEncoded = '2071U/NKd5KzeimvyflGLYku6JfI9Mms2wGxWoCLmx9+0=,10LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=';
+const keyInfoCookieEncoded = '2071U/NKd5KzeimvyflGLYku6JfI9Mms2wGxWoCLmx9+0=#10LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=';
 
 /** @type {string} */
 const cookie = `k=${keyInfoCookieEncoded}; accounts=${JSON.stringify(deprecatedAccountCookies)}; some=thing`;

--- a/tests/DummyData.spec.js
+++ b/tests/DummyData.spec.js
@@ -149,7 +149,7 @@ const deprecatedAccount2Keys = () => [
 const keyInfoCookieEncoded = '2071U/NKd5KzeimvyflGLYku6JfI9Mms2wGxWoCLmx9+0=,10LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=';
 
 /** @type {string} */
-const cookie = `k=${keyInfoCookieEncoded};accounts=${JSON.stringify(deprecatedAccountCookies)};some=thing;`;
+const cookie = `k=${keyInfoCookieEncoded}; accounts=${JSON.stringify(deprecatedAccountCookies)}; some=thing`;
 
 const DUMMY_ACCOUNT_DATABASE_NAME = 'keyguard-dummy-account-database';
 const DUMMY_KEY_DATABASE_NAME = 'keyguard-dummy-key-database';

--- a/tests/lib/CookieJar.spec.js
+++ b/tests/lib/CookieJar.spec.js
@@ -12,10 +12,13 @@ describe('CookieJar', () => {
     });
 
     it('can be filled with key info', () => {
+        /** @type {string} */
+        let cookies = '';
         spyOnProperty(document, 'cookie', 'set').and.callFake((/** @type {string} */ cookie) => {
-            const cookieValue = cookie.split(';')[0];
-            expect(cookieValue).toEqual(`k=${Dummy.keyInfoCookieEncoded}`);
+            expect(cookie.startsWith(`k=${Dummy.keyInfoCookieEncoded};`)).toBe(true);
+            cookies = `${cookies ? `${cookies}; ` : ''}${cookie.split(';')[0]}`;
         });
+        spyOnProperty(document, 'cookie', 'get').and.callFake(() => cookies);
         CookieJar.fillKeys(Dummy.keyInfos());
     });
 

--- a/tests/lib/CookieJar.spec.js
+++ b/tests/lib/CookieJar.spec.js
@@ -3,11 +3,11 @@
 
 describe('CookieJar', () => {
     it('can encode keys', () => {
-        expect(CookieJar._encodeCookie(Dummy.keyInfos())).toBe(Dummy.keyInfoCookieEncoded);
+        expect(CookieJar._encodeKeysCookie(Dummy.keyInfos())).toBe(Dummy.keyInfoCookieEncoded);
     });
 
     it('can decode a cookie', () => {
-        const decoded = CookieJar._decodeCookie(Dummy.keyInfoCookieEncoded);
+        const decoded = CookieJar._decodeKeysCookie(Dummy.keyInfoCookieEncoded);
         expect(decoded).toEqual(Dummy.cookieKeyInfos());
     });
 
@@ -16,14 +16,14 @@ describe('CookieJar', () => {
             const cookieValue = cookie.split(';')[0];
             expect(cookieValue).toEqual(`k=${Dummy.keyInfoCookieEncoded}`);
         });
-        CookieJar.fill(Dummy.keyInfos());
+        CookieJar.fillKeys(Dummy.keyInfos());
     });
 
     it('can be eaten from', () => {
         spyOnProperty(document, 'cookie', 'get').and.returnValue(Dummy.cookie);
-        const deprecatedAccountInfo = CookieJar.eatDeprecated();
+        const deprecatedAccountInfo = CookieJar.eatDeprecatedAccounts();
         expect(deprecatedAccountInfo).toEqual(Dummy.deprecatedAccountInfos);
-        const keyInfo = CookieJar.eat();
+        const keyInfo = CookieJar.eatKeys();
         expect(keyInfo).toEqual(Dummy.cookieKeyInfos());
     });
 });

--- a/tests/lib/IframeApi.spec.js
+++ b/tests/lib/IframeApi.spec.js
@@ -7,14 +7,17 @@
 
 describe('IframeApi', () => {
     const iframeApi = new IFrameApi();
+    /** @type {string} */
+    let cookies = '';
 
     beforeEach(() => {
+        cookies = Dummy.cookie;
         spyOn(CookieJar, 'eatKeys').and.callThrough();
         spyOn(CookieJar, 'eatDeprecatedAccounts').and.callThrough();
         spyOn(AccountStore.prototype, 'list').and.callThrough();
         spyOn(KeyStore.prototype, 'list').and.callThrough();
         spyOn(KeyStore.prototype, 'migrateAccountsToKeys').and.callThrough();
-        spyOnProperty(document, 'cookie', 'get').and.returnValue(Dummy.cookie);
+        spyOnProperty(document, 'cookie', 'get').and.callFake(() => cookies);
     });
 
     it('can list deprecated accounts from cookies on iOS.', async () => {
@@ -75,6 +78,7 @@ describe('IframeApi', () => {
         spyOnProperty(document, 'cookie', 'set').and.callFake((/** @type {string} */ cookie) => {
             expect(cookie.startsWith('migrate=1;')).toBe(true);
             cookieSet = true;
+            cookies = `${cookies ? `${cookies}; ` : ''}${cookie.split(';')[0]}`;
         });
 
         await iframeApi.migrateAccountsToKeys(null);

--- a/tests/lib/IframeApi.spec.js
+++ b/tests/lib/IframeApi.spec.js
@@ -9,8 +9,8 @@ describe('IframeApi', () => {
     const iframeApi = new IFrameApi();
 
     beforeEach(() => {
-        spyOn(CookieJar, 'eat').and.callThrough();
-        spyOn(CookieJar, 'eatDeprecated').and.callThrough();
+        spyOn(CookieJar, 'eatKeys').and.callThrough();
+        spyOn(CookieJar, 'eatDeprecatedAccounts').and.callThrough();
         spyOn(AccountStore.prototype, 'list').and.callThrough();
         spyOn(KeyStore.prototype, 'list').and.callThrough();
         spyOn(KeyStore.prototype, 'migrateAccountsToKeys').and.callThrough();
@@ -22,7 +22,7 @@ describe('IframeApi', () => {
 
         const listedAccounts = await iframeApi.listLegacyAccounts(null);
 
-        expect(CookieJar.eatDeprecated).toHaveBeenCalled();
+        expect(CookieJar.eatDeprecatedAccounts).toHaveBeenCalled();
         expect(AccountStore.instance.list).not.toHaveBeenCalled();
         expect(KeyStore.instance.list).not.toHaveBeenCalled();
         expect(listedAccounts).toEqual(Dummy.deprecatedAccount2KeyInfoObjects());
@@ -33,7 +33,7 @@ describe('IframeApi', () => {
 
         const listedKeys = await iframeApi.list(null);
 
-        expect(CookieJar.eat).toHaveBeenCalled();
+        expect(CookieJar.eatKeys).toHaveBeenCalled();
         expect(AccountStore.instance.list).not.toHaveBeenCalled();
         expect(KeyStore.instance.list).not.toHaveBeenCalled();
         expect(listedKeys).toEqual(Dummy.keyInfoObjects());
@@ -45,7 +45,7 @@ describe('IframeApi', () => {
 
         const listedAccounts = await iframeApi.listLegacyAccounts(null);
 
-        expect(CookieJar.eat).not.toHaveBeenCalled();
+        expect(CookieJar.eatKeys).not.toHaveBeenCalled();
         expect(AccountStore.instance.list).toHaveBeenCalled();
         expect(KeyStore.instance.list).not.toHaveBeenCalled();
         expect(listedAccounts).toEqual(Dummy.deprecatedAccount2KeyInfoObjects());
@@ -59,7 +59,7 @@ describe('IframeApi', () => {
 
         const listedKeyObjects = await iframeApi.list(null);
 
-        expect(CookieJar.eat).not.toHaveBeenCalled();
+        expect(CookieJar.eatKeys).not.toHaveBeenCalled();
         expect(AccountStore.instance.list).not.toHaveBeenCalled();
         expect(KeyStore.instance.list).toHaveBeenCalled();
         expect(listedKeyObjects).toEqual(Dummy.keyInfoObjects());


### PR DESCRIPTION
This pull request introduces a `NonPartitionedSessionStorage` class to circumvent the [issues that Safari introduced in 16.1. by partitioning `sessionStorage` between top-level and iframe contexts](https://bugs.webkit.org/show_bug.cgi?id=247565).
Under the hood, now cookies are used if the `sessionStorage` is detected as being partitioned.
For this, cookie handling has been unified in the `CookieJar` and generally been made more resilient and complete.
On top of the `CookieJar`, which handles plain cookies, a `CookieStorage` has been built which can encode arbitrary data of (practically) arbitrary size into cookies, and encrypts them by default to avoid sensitive data getting leaked to the server.
The cookie-stripping Cookie Monster service worker has now also been enabled as an additional measure to avoid cookies leaking to the server.
I did not observe the previous issues we had a few years ago in Safari with multiple service workers in the same tab (in the top-level window and the iframe). This was however on localhost (with wallet and hub built as production, to enable their service workers). Eventually, I would like to test this in a testnet deployment.

The login flow and swap flow have been adapted to now use the `NonPartitionedSessionStorage` instead of the `sessionStorage`.
These are accompanied with small changes to the Hub to forward the potentially created `CookieStorage` encryption keys.
I'll push those changes tomorrow. They'll also require a Keyguard client version update when released.

The `CookieStorage` and `NonPartitionedSessionStorage` have been implemented in a generic fashion, and not too specific to the login and swap use-cases, with the idea in mind to also be able to use them instead of the Safari keys cookie, to lift the limit on maximum accounts the user can be logged into. Also, the concept of the `NonPartitionedSessionStorage` can be extended to longer-lived storage to maybe be used as a replacement in Safari for the partitioned indexedDB, too.

I guess, I should also add some tests for the new libraries.