### PR TITLE
Add autocomplete attribute to password inputs

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -6,19 +6,22 @@
 class PasswordInput extends Nimiq.Observable {
     /**
      * @param {?HTMLElement} $el
-     * @param {number} [maxLength]
-     * @param {string} [placeholder]
+     * @param {object} [options]
+     * @param {number} [options.maxLength]
+     * @param {string} [options.placeholder]
+     * @param {'current-password' | 'new-password'} [options.autocomplete]
      */
-    constructor($el, maxLength, placeholder = '••••••••') {
+    constructor($el, options = {}) {
         super();
         this._minLength = PasswordInput.DEFAULT_MIN_LENGTH;
-        this._maxLength = maxLength || Infinity;
+        this._maxLength = options.maxLength || Infinity;
         this.$el = PasswordInput._createElement($el);
 
         this.$input = /** @type {HTMLInputElement} */ (this.$el.querySelector('input.password'));
         this.$eyeButton = /** @type {HTMLElement} */ (this.$el.querySelector('.eye-button'));
 
-        this.$input.placeholder = placeholder;
+        this.$input.placeholder = options.placeholder || '••••••••';
+        this.$input.autocomplete = options.autocomplete || 'current-password';
 
         this.$eyeButton.addEventListener('click', () => {
             this._changeVisibility();

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -7,9 +7,9 @@ class PasswordInput extends Nimiq.Observable {
     /**
      * @param {?HTMLElement} $el
      * @param {object} [options]
-     * @param {number} [options.maxLength]
-     * @param {string} [options.placeholder]
-     * @param {'current-password' | 'new-password'} [options.autocomplete]
+     * @param {number=} [options.maxLength = Infinity]
+     * @param {string=} [options.placeholder = '••••••••']
+     * @param {'current-password' | 'new-password' | undefined} [options.autocomplete = 'current-password']
      */
     constructor($el, options = {}) {
         super();

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -28,7 +28,10 @@ class PasswordSetterBox extends Nimiq.Observable {
 
         this._passwordInput = new PasswordInput(
             this.$el.querySelector('[password-input]'),
-            PasswordSetterBox.PASSWORD_MAX_LENGTH,
+            {
+                maxLength: PasswordSetterBox.PASSWORD_MAX_LENGTH,
+                autocomplete: 'new-password',
+            },
         );
         this._passwordInput.on(PasswordInput.Events.VALID, isValid => this._onInputChangeValidity(isValid));
         this._passwordInput.on(


### PR DESCRIPTION
Chrome was always warning about missing autocomplete attribute for the password inputs. This adds it.

Defaults to `current-password`, so the regular PasswordBox gets that, as it doesn't set anything in the constructor. For the PasswordSetterBox, we select `new-password`, so that browsers and password managers can suggest a new safe password.