### PR TITLE
Fixes to PR#459 (Safari sessionStorage partitioning fix)

### DIFF
--- a/src/lib/AutoComplete.js
+++ b/src/lib/AutoComplete.js
@@ -20,7 +20,7 @@ class AutoComplete { // eslint-disable-line no-unused-vars
          * @param {Node} context
          */
         function live(elClass, event, cb, context = document) {
-            context.addEventListener(event, e => {
+            context.addEventListener(event, /** @param {Event} e */ e => {
                 let el = /** @type {HTMLElement | null} */ (e.target || e.srcElement);
                 let found = false;
                 do {

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -54,7 +54,8 @@ class CookieJar { // eslint-disable-line no-unused-vars
      * @returns {string | null}
      */
     static readCookie(name) {
-        const cookieMatch = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape regex special chars.
+        const cookieMatch = document.cookie.match(new RegExp(`(?:^|; )${escapedName}=([^;]*)`));
         return cookieMatch ? cookieMatch[1] : null;
     }
 

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -183,13 +183,13 @@ class CookieJar { // eslint-disable-line no-unused-vars
 
 /**
  * @readonly
- * @enum { 'lang' | 'k' | 'removeKey' | 'ssnp' | 'cs.' | 'npss.' | 'accounts' | 'migrate' }
+ * @enum { 'lang' | 'k' | 'removeKey' | 'ssp' | 'cs.' | 'npss.' | 'accounts' | 'migrate' }
  */
 CookieJar.Cookie = {
     LANGUAGE: /** @type {'lang'} */ ('lang'),
     KEYS: /** @type {'k'} */ ('k'),
     REMOVE_KEY: /** @type {'removeKey'} */ ('removeKey'),
-    FLAG_SESSION_STORAGE_NOT_PARTITIONED: /** @type {'ssnp'} */ ('ssnp'),
+    FLAG_SESSION_STORAGE_PARTITIONED: /** @type {'ssp'} */ ('ssp'),
     NAMESPACE_COOKIE_STORAGE: /** @type {'cs.'} */ ('cs.'), // no other cookies start with 'cs.'
     NAMESPACE_NON_PARTITIONED_SESSION_STORAGE: /** @type {'npss.'} */ ('npss.'), // no other cookies start with 'npss.'
     /**

--- a/src/lib/NonPartitionedSessionStorage.js
+++ b/src/lib/NonPartitionedSessionStorage.js
@@ -151,9 +151,23 @@ class NonPartitionedSessionStorage {
         // instead of hub.nimiq.com). If this change happens, the Keyguard's sessionStorage would not be partitioned
         // anymore between the Keyguard top-level and Keyguard iframe within the Hub, because the Keyguard and Hub live
         // on the same eTLD+1. This issue is tracked here: https://bugs.webkit.org/show_bug.cgi?id=247565
-        if (!BrowserDetection.isSafari()) return false;
-        const safariVersion = BrowserDetection.safariVersion();
-        return safariVersion[0] >= 16 && safariVersion[1] >= 1;
+        // On iOS, we have to include all browsers, because they all use Safari's WebKit engine, the version of which is
+        // determined by the iOS version.
+        /**
+         * @param {number[]} version
+         * @param {number[]} referenceVersion
+         * @returns {boolean}
+         */
+        const isVersionAtLeast = (version, referenceVersion) => {
+            for (let i = 0; i < Math.min(version.length, referenceVersion.length); ++i) {
+                if (version[i] > referenceVersion[i]) return true;
+                if (version[i] < referenceVersion[i]) return false;
+            }
+            return version.length >= referenceVersion.length;
+        };
+        const firstBadSafari = [16, 1];
+        return (BrowserDetection.isSafari() && isVersionAtLeast(BrowserDetection.safariVersion(), firstBadSafari))
+            || (BrowserDetection.isIOS() && isVersionAtLeast(BrowserDetection.iOSVersion(), firstBadSafari));
     }
 
     static hasSessionStorageAccess() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "target": "ES2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["DOM"],                           /* Specify library files to be included in the compilation. */
+    "skipLibCheck": true,                     /* Skip checking .d.ts files. We need this currently, because types in */
+                                              /* lib.webworker.d.ts referenced in ServiceWorker.js clash with types */
+                                              /* in lib.dom.d.ts */
+                                              /* TODO once typescript has been updated, this can be reset to false. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     "checkJs": true,                          /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
This PR includes 4 fixes to previous [PR#459](https://github.com/nimiq/keyguard/pull/459) (Safari sessionStorage partitioning fix):
- Regex special chars in cookie names lead to this cookie not being found in `document.cookie` and not being readable with `CookieJar.readCookie`.
- On iOS, all browsers use Safari's WebKit enginge, however browsers other than Safari were not detected as partitioning the sessionStorage. I think it should be working now, but unfortunately, I can't test this with BrowserStack.
- The previous Safari version check did not check the version parts individually and would for example wrongly have identified 17.0. as not being newer than 16.1.
- Firefox does not forward the page referrer to `document.referrer` if a service worker is involved. A workaround has been implemented to still make it work.

Additionally, the feature detection whether the sessionStorage is partitioned has been improved by detecting cases as being partitioned where the Keyguard is known to be open as top level in the same tab before, but the top level sessionStorage entries are not readable.