### PR TITLE
Fix bug in iOS>=16.4 where the right side of a rotation-container was…

### DIFF
--- a/src/components/FlippableHandler.css
+++ b/src/components/FlippableHandler.css
@@ -13,6 +13,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    pointer-events: none;
 }
 
 #rotation-container.disable-transition {
@@ -30,6 +31,7 @@
     backface-visibility: hidden;
     overflow: hidden;
     margin: inherit;
+    pointer-events: auto;
 }
 
 #rotation-container > .page.display-flex:not(:target) { /* :not(:target) is only required for specificity */


### PR DESCRIPTION
… not interactive

By making the rotation container not interactive, but the children yes, everything on the page can be clicked (tapped) again.