### PR TITLE
Correctly count length of password with multibyte characters

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -100,6 +100,7 @@ class PasswordInput extends Nimiq.Observable {
     }
 
     _onInputChanged() {
+        // Split string by characters, not code points, to get the character count
         const passwordLength = [...this.$input.value].length;
         this.valid = passwordLength >= this._minLength && passwordLength <= this._maxLength;
 

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -100,7 +100,7 @@ class PasswordInput extends Nimiq.Observable {
     }
 
     _onInputChanged() {
-        const passwordLength = this.$input.value.length;
+        const passwordLength = [...this.$input.value].length;
         this.valid = passwordLength >= this._minLength && passwordLength <= this._maxLength;
 
         this.fire(PasswordInput.Events.LENGTH, passwordLength);

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -143,8 +143,10 @@ class PasswordSetterBox extends Nimiq.Observable {
             this._repeatPasswordTimout = null;
         }
 
+        const inputLength = [...this._passwordInput.text].length;
+
         if (this._password) {
-            if (this._passwordInput.text.length > 0 && this._passwordInput.text.length < this._password.length) {
+            if (inputLength > 0 && inputLength < [...this._password].length) {
                 this._repeatPasswordTimout = window.setTimeout(
                     () => {
                         this.$el.classList.remove('repeat-long');
@@ -158,15 +160,14 @@ class PasswordSetterBox extends Nimiq.Observable {
         }
 
         const score = PasswordStrength.strength(this._passwordInput.text);
-        const length = this._passwordInput.text.length;
 
         this.$el.classList.toggle(
             'input-eligible',
-            isValid && (!this._password || this._passwordInput.text.length >= this._password.length),
+            isValid && (!this._password || inputLength >= [...this._password].length),
         );
 
-        this.$el.classList.toggle('too-long', length > PasswordSetterBox.PASSWORD_MAX_LENGTH);
-        this.$el.classList.toggle('strength-short', !isValid && length <= PasswordSetterBox.PASSWORD_MAX_LENGTH);
+        this.$el.classList.toggle('too-long', inputLength > PasswordSetterBox.PASSWORD_MAX_LENGTH);
+        this.$el.classList.toggle('strength-short', !isValid && inputLength <= PasswordSetterBox.PASSWORD_MAX_LENGTH);
         this.$el.classList.toggle('strength-weak', isValid && score < PasswordStrength.Score.MINIMUM);
         this.$el.classList.toggle('strength-good',
             isValid
@@ -180,7 +181,7 @@ class PasswordSetterBox extends Nimiq.Observable {
     }
 
     _isPasswordEligible() {
-        return this._passwordInput.text.length >= PasswordInput.DEFAULT_MIN_LENGTH;
+        return [...this._passwordInput.text].length >= PasswordInput.DEFAULT_MIN_LENGTH;
     }
 
     /**
@@ -207,7 +208,7 @@ class PasswordSetterBox extends Nimiq.Observable {
             this._passwordInput.reset();
             return;
         }
-        if (this._passwordInput.text.length >= this._password.length) {
+        if ([...this._passwordInput.text].length >= [...this._password].length) {
             this.$el.classList.remove('repeat-short');
             this.$el.classList.add('repeat-long');
             await AnimationUtils.animate('shake', this.$el);

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -143,6 +143,7 @@ class PasswordSetterBox extends Nimiq.Observable {
             this._repeatPasswordTimout = null;
         }
 
+        // Split string by characters, not code points, to get the character count
         const inputLength = [...this._passwordInput.text].length;
 
         if (this._password) {

--- a/src/lib/PasswordStrength.js
+++ b/src/lib/PasswordStrength.js
@@ -45,13 +45,21 @@ class PasswordStrength {
 
         const baseScore = 30;
 
-        for (let i = 0; i < password.length; i++) {
-            if (password.charAt(i).match(/[A-Z]/g)) { count.upperCase += 1; }
-            if (password.charAt(i).match(/[0-9]/g)) { count.numbers += 1; }
-            if (password.charAt(i).match(/(.*[!,@,#,$,%,^,&,*,?,_,~])/)) { count.symbols += 1; }
+        const characters = [...password];
+        const length = characters.length;
+
+        for (let i = 0; i < length; i++) {
+            if (characters[i].match(/[A-Z]/g)) {
+                count.upperCase += 1;
+            } else if (characters[i].match(/[0-9]/g)) {
+                count.numbers += 1;
+            } else if (characters[i].match(/[^a-z]/)) {
+                // Count everything else that is not a lowercase letter as a symbol
+                count.symbols += 1;
+            }
         }
 
-        count.excess = password.length - minLength;
+        count.excess = length - minLength;
 
         if (count.upperCase && count.numbers && count.symbols) {
             weight.combo = 25;

--- a/src/lib/PasswordStrength.js
+++ b/src/lib/PasswordStrength.js
@@ -45,6 +45,7 @@ class PasswordStrength {
 
         const baseScore = 30;
 
+        // Split string by characters, not code points
         const characters = [...password];
         const length = characters.length;
 

--- a/src/lib/PasswordStrength.js
+++ b/src/lib/PasswordStrength.js
@@ -54,7 +54,7 @@ class PasswordStrength {
                 count.upperCase += 1;
             } else if (characters[i].match(/[0-9]/g)) {
                 count.numbers += 1;
-            } else if (characters[i].match(/[^a-z]/)) {
+            } else if (!characters[i].match(/[a-z]/)) {
                 // Count everything else that is not a lowercase letter as a symbol
                 count.symbols += 1;
             }


### PR DESCRIPTION
This PR fixes the way password character length is counted to use the [recommended method from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length#strings_with_length_not_equal_to_the_number_of_characters) for strings with potential multibyte characters.

Additionally, this method is applied to the password strength calculator to always handle full characters, not ["lone surrogates"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt#using_charat).