### PR TITLE
Allow use of sign-polygon-transaction flow for re-signing USDC redeem transactions

### DIFF
--- a/src/request/sign-polygon-transaction/SignPolygonTransaction.js
+++ b/src/request/sign-polygon-transaction/SignPolygonTransaction.js
@@ -32,7 +32,7 @@ class SignPolygonTransaction {
 
         /** @type {HTMLLinkElement} */
         const $sender = (this.$el.querySelector('.accounts .sender'));
-        if (request.description.name === 'refund') {
+        if (['redeem', 'redeemWithSecretInData', 'refund'].includes(request.description.name)) {
             new PolygonAddressInfo(relayRequest.to, request.senderLabel, 'unknown').renderTo($sender);
         } else if (request.description.name === 'swap' || request.description.name === 'swapWithApproval') {
             new PolygonAddressInfo(relayRequest.from, 'USDC.e', 'usdc_dark').renderTo($sender);
@@ -42,20 +42,14 @@ class SignPolygonTransaction {
 
         /** @type {HTMLLinkElement} */
         const $recipient = (this.$el.querySelector('.accounts .recipient'));
-        if (request.description.name === 'refund') {
-            new PolygonAddressInfo(
-                /** @type {string} */ (request.description.args.target),
-                request.keyLabel,
-                'usdc',
-            ).renderTo($recipient);
+        if (['redeem', 'redeemWithSecretInData', 'refund'].includes(request.description.name)) {
+            const recipientAddress = /** @type {string} */ (request.description.args.target);
+            new PolygonAddressInfo(recipientAddress, request.keyLabel, 'usdc').renderTo($recipient);
         } else if (request.description.name === 'swap' || request.description.name === 'swapWithApproval') {
             new PolygonAddressInfo(relayRequest.from, 'USDC', 'usdc').renderTo($recipient);
         } else {
-            new PolygonAddressInfo(
-                /** @type {string} */ (request.description.args.target),
-                request.recipientLabel,
-                'none',
-            ).renderTo($recipient);
+            const recipientAddress = /** @type {string} */ (request.description.args.target);
+            new PolygonAddressInfo(recipientAddress, request.recipientLabel, 'none').renderTo($recipient);
         }
 
         /** @type {HTMLDivElement} */
@@ -65,7 +59,7 @@ class SignPolygonTransaction {
 
         // Set value and fee.
         $value.textContent = NumberFormatting.formatNumber(
-            PolygonUtils.unitsToCoins(request.description.name === 'refund'
+            PolygonUtils.unitsToCoins(['redeem', 'redeemWithSecretInData', 'refund'].includes(request.description.name)
                 ? /** @type {number} */ (request.amount)
                 : request.description.args.amount.toNumber()),
             6,
@@ -192,10 +186,10 @@ class SignPolygonTransaction {
             ]);
         }
 
-        if (request.description.name === 'refund') {
+        if (['redeem', 'redeemWithSecretInData', 'refund'].includes(request.description.name)) {
             const derivedAddress = polygonKey.deriveAddress(request.keyPath);
             if (request.description.args.target !== derivedAddress) {
-                reject(new Errors.InvalidRequestError('Refund target does not match derived address'));
+                reject(new Errors.InvalidRequestError('Target address argument does not match derived address'));
                 return;
             }
         }

--- a/src/request/swap-iframe/SwapIFrameApi.js
+++ b/src/request/swap-iframe/SwapIFrameApi.js
@@ -710,7 +710,7 @@ class SwapIFrameApi extends BitcoinRequestParserMixin(RequestParser) { // eslint
                     /* bytes32 id */ parsedRequest.redeem.htlcId,
                     /* address target */ storedRequest.redeem.description.args.target,
                     ...(storedRequest.redeem.description.name === 'redeem' ? [
-                        /* uint256 secret */ storedRequest.redeem.description.args.secret,
+                        /* bytes32 secret */ storedRequest.redeem.description.args.secret,
                     ] : []),
                     /* uint256 fee */ storedRequest.redeem.description.args.fee,
                 ],

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -306,6 +306,8 @@ type Parsed<T extends KeyguardRequest.Request> =
         KeyId2KeyInfo<KeyguardRequest.SignPolygonTransactionRequest>
         & { description: PolygonTransferDescription
             | PolygonTransferWithPermitDescription
+            | PolygonRedeemDescription
+            | PolygonRedeemWithSecretInDataDescription
             | PolygonRefundDescription
             | PolygonSwapDescription
             | PolygonSwapWithApprovalDescription } :


### PR DESCRIPTION
To enable resigning a USDC swap redeem transaction, we are going to re-use the regular sign-polygon-transaction flow. This PR extends the types and checks to allow that.