### PR TITLE
Fiat api refactor

### DIFF
--- a/src/components/PaymentInfoLine.js
+++ b/src/components/PaymentInfoLine.js
@@ -20,6 +20,15 @@
  *      expires?: number
  *  }} PaymentInfo */
 
+/**
+ * @type {Record<FiatApi.SupportedProvider, string>}
+ * As Record such that ts notifies us, if an entry is missing.
+ */
+const FIAT_API_PROVIDER_URLS = {
+    [FiatApi.SupportedProvider.CoinGecko]: 'coingecko.com',
+};
+const FIAT_API_PROVIDER_URL = FIAT_API_PROVIDER_URLS[FiatApi.Provider];
+
 class PaymentInfoLine { // eslint-disable-line no-unused-vars
     /**
      * @param {PaymentInfo} paymentInfo
@@ -249,7 +258,9 @@ class PaymentInfoLine { // eslint-disable-line no-unused-vars
 
             // Converted to absolute percent, rounded to one decimal
             const formattedRateDeviation = `${Math.round(Math.abs(rateDeviation) * 100 * 10) / 10}%`;
-            $rateInfo.textContent = rateInfo.replace('%RATE_DEVIATION%', formattedRateDeviation);
+            $rateInfo.textContent = rateInfo
+                .replace('{formattedRateDeviation}', formattedRateDeviation)
+                .replace('{provider}', FIAT_API_PROVIDER_URL);
 
             $rateInfo.style.display = 'block';
         } else {

--- a/src/lib/FiatApi.js
+++ b/src/lib/FiatApi.js
@@ -48,9 +48,9 @@ FiatApi.SupportedCryptoCurrency = {
 /**
  * @readonly
  * @enum {'aed' | 'ars' | 'aud' | 'bdt' | 'bhd' | 'bmd' | 'brl' | 'cad' | 'chf' | 'clp' | 'cny' | 'czk' | 'dkk' | 'eur'
- *     | 'gbp' | 'hkd' | 'huf' | 'idr' | 'ils' | 'inr' | 'jpy' | 'krw' | 'kwd' | 'lkr' | 'mmk' | 'mxn' | 'myr' | 'nok'
- *     | 'ngn' | 'nzd' | 'php' | 'pkr' | 'pln' | 'rub' | 'sar' | 'sek' | 'sgd' | 'thb' | 'try' | 'twd' | 'uah' | 'usd'
- *     | 'vnd' | 'zar'}
+ *     | 'gbp' | 'gel' | 'hkd' | 'huf' | 'idr' | 'ils' | 'inr' | 'jpy' | 'krw' | 'kwd' | 'lkr' | 'mmk' | 'mxn' | 'myr'
+ *     | 'ngn' | 'nok' | 'nzd' | 'php' | 'pkr' | 'pln' | 'rub' | 'sar' | 'sek' | 'sgd' | 'thb' | 'try' | 'twd' | 'uah'
+ *     | 'usd' | 'vnd' | 'zar'}
  * Fiat currencies supported by the coingecko api. Note that coingecko supports more vs_currencies (see
  * https://api.coingecko.com/api/v3/simple/supported_vs_currencies) but also includes crypto currencies and ounces of
  * gold amongst others that are not fiat currencies. See FiatApi in @nimiq/utils for how this list was assembled.
@@ -71,6 +71,7 @@ FiatApi.SupportedFiatCurrency = {
     DKK: /** @type {'dkk'} */ ('dkk'), // Danish Krone
     EUR: /** @type {'eur'} */ ('eur'), // Euro
     GBP: /** @type {'gbp'} */ ('gbp'), // British Pound
+    GEL: /** @type {'gel'} */ ('gel'), // Georgian Lari
     HKD: /** @type {'hkd'} */ ('hkd'), // Hong Kong Dollar
     HUF: /** @type {'huf'} */ ('huf'), // Hungarian Forint
     IDR: /** @type {'idr'} */ ('idr'), // Indonesian Rupiah
@@ -83,8 +84,8 @@ FiatApi.SupportedFiatCurrency = {
     MMK: /** @type {'mmk'} */ ('mmk'), // Burmese Kyat
     MXN: /** @type {'mxn'} */ ('mxn'), // Mexican Peso
     MYR: /** @type {'myr'} */ ('myr'), // Malaysian Ringgit
-    NOK: /** @type {'nok'} */ ('nok'), // Norwegian Krone
     NGN: /** @type {'ngn'} */ ('ngn'), // Nigerian Naira
+    NOK: /** @type {'nok'} */ ('nok'), // Norwegian Krone
     NZD: /** @type {'nzd'} */ ('nzd'), // New Zealand Dollar
     PHP: /** @type {'php'} */ ('php'), // Philippine Peso
     PKR: /** @type {'pkr'} */ ('pkr'), // Pakistani Rupee
@@ -107,7 +108,7 @@ FiatApi.SupportedFiatCurrency = {
  * @readonly
  * Coingecko api url. Note that the origin must be whitelisted in the csp.
  */
-FiatApi.API_URL = 'https://nq-coingecko-proxy.deno.dev/api/v3';
+FiatApi.API_URL = 'https://api.coingecko.com/api/v3';
 
 /**
  * @readonly

--- a/src/lib/FiatApi.js
+++ b/src/lib/FiatApi.js
@@ -11,110 +11,140 @@ class FiatApi {
      * >>>}
      */
     static async getExchangeRates(cryptoCurrencies, vsCurrencies) {
-        const coinIds = cryptoCurrencies.map(currency => FiatApi.COINGECKO_COIN_IDS[currency]);
-        const response = await fetch(
-            `${FiatApi.API_URL}/simple/price?ids=${coinIds.join(',')}&vs_currencies=${vsCurrencies.join(',')}`,
-        );
-        if (!response.ok) throw new Error(`Failed to fetch exchange rates: ${response.status}`);
-        const apiResult = await response.json();
-        // Map coingecko coin ids back to SupportedCryptoCurrency enum and sanitize retrieved data.
-        return cryptoCurrencies.reduce((result, cryptoCurrency) => {
-            const record = apiResult[FiatApi.COINGECKO_COIN_IDS[cryptoCurrency]];
-            const sanitizedRecord = Object.keys(record).reduce((sanitized, fiatCurrency) => ({
-                ...sanitized,
-                ...(Object.values(FiatApi.SupportedFiatCurrency).includes(/** @type {any} */ (fiatCurrency))
-                    ? { [fiatCurrency]: parseFloat(record[fiatCurrency]) }
-                    : null
-                ),
-            }), {});
-            return {
-                ...result,
-                [cryptoCurrency]: sanitizedRecord,
-            };
-        }, {});
+        switch (FiatApi.Provider) { // eslint-disable-line default-case
+            case FiatApi.SupportedProvider.CoinGecko: {
+                const coinIds = cryptoCurrencies.map(currency => FiatApi.COINGECKO_COIN_IDS[currency]);
+                const response = await fetch(
+                    `${FiatApi.API_URL}/simple/price?ids=${coinIds.join(',')}&vs_currencies=${vsCurrencies.join(',')}`,
+                );
+                if (!response.ok) throw new Error(`Failed to fetch exchange rates: ${response.status}`);
+                const apiResult = await response.json();
+                // Map coingecko coin ids back to SupportedCryptoCurrency enum and sanitize retrieved data.
+                return cryptoCurrencies.reduce((result, cryptoCurrency) => {
+                    const record = apiResult[FiatApi.COINGECKO_COIN_IDS[cryptoCurrency]];
+                    const sanitizedRecord = Object.keys(record).reduce((sanitized, fiatCurrency) => ({
+                        ...sanitized,
+                        ...(Object.values(FiatApi.SupportedFiatCurrency).includes(/** @type {any} */ (fiatCurrency))
+                            ? { [fiatCurrency]: parseFloat(record[fiatCurrency]) }
+                            : null
+                        ),
+                    }), {});
+                    return {
+                        ...result,
+                        [cryptoCurrency]: sanitizedRecord,
+                    };
+                }, {});
+            }
+        }
+        // Not as default case to let ts warn us on missing providers in switch statement above.
+        throw new Error(`FiatApi.Provider ${FiatApi.Provider} not supported yet.`);
     }
 }
 
 /**
  * @readonly
- * @enum { 'nim' | 'btc' }
- * Crypto currencies supported by the coingecko api that are currently of interest for us.
+ * @enum { 'CoinGecko' }
+ * Supported API providers.
  */
-FiatApi.SupportedCryptoCurrency = {
-    NIM: /** @type {'nim'} */ ('nim'),
-    BTC: /** @type {'btc'} */ ('btc'),
+FiatApi.SupportedProvider = {
+    CoinGecko: /** @type {'CoinGecko'} */ ('CoinGecko'),
 };
 
 /**
  * @readonly
- * @enum {'aed' | 'ars' | 'aud' | 'bdt' | 'bhd' | 'bmd' | 'brl' | 'cad' | 'chf' | 'clp' | 'cny' | 'czk' | 'dkk' | 'eur'
- *     | 'gbp' | 'gel' | 'hkd' | 'huf' | 'idr' | 'ils' | 'inr' | 'jpy' | 'krw' | 'kwd' | 'lkr' | 'mmk' | 'mxn' | 'myr'
- *     | 'ngn' | 'nok' | 'nzd' | 'php' | 'pkr' | 'pln' | 'rub' | 'sar' | 'sek' | 'sgd' | 'thb' | 'try' | 'twd' | 'uah'
- *     | 'usd' | 'vnd' | 'zar'}
- * Fiat currencies supported by the coingecko api. Note that coingecko supports more vs_currencies (see
- * https://api.coingecko.com/api/v3/simple/supported_vs_currencies) but also includes crypto currencies and ounces of
- * gold amongst others that are not fiat currencies. See FiatApi in @nimiq/utils for how this list was assembled.
+ * @type {FiatApi.SupportedProvider}
+ * The effective provider used by the FiatApi. As this is not meant to be changeable at runtime, all code for other
+ * providers can be commented out, to avoid type confusion.
  */
-FiatApi.SupportedFiatCurrency = {
-    AED: /** @type {'aed'} */ ('aed'), // Arab Emirates Dirham
-    ARS: /** @type {'ars'} */ ('ars'), // Argentine Peso
-    AUD: /** @type {'aud'} */ ('aud'), // Australian Dollar
-    BDT: /** @type {'bdt'} */ ('bdt'), // Bangladeshi Taka
-    BHD: /** @type {'bhd'} */ ('bhd'), // Bahraini Dinar
-    BMD: /** @type {'bmd'} */ ('bmd'), // Bermudan Dollar
-    BRL: /** @type {'brl'} */ ('brl'), // Brazilian Real
-    CAD: /** @type {'cad'} */ ('cad'), // Canadian Dollar
-    CHF: /** @type {'chf'} */ ('chf'), // Swiss Franc
-    CLP: /** @type {'clp'} */ ('clp'), // Chilean Peso
-    CNY: /** @type {'cny'} */ ('cny'), // Chinese Yuan
-    CZK: /** @type {'czk'} */ ('czk'), // Czech Koruna
-    DKK: /** @type {'dkk'} */ ('dkk'), // Danish Krone
-    EUR: /** @type {'eur'} */ ('eur'), // Euro
-    GBP: /** @type {'gbp'} */ ('gbp'), // British Pound
-    GEL: /** @type {'gel'} */ ('gel'), // Georgian Lari
-    HKD: /** @type {'hkd'} */ ('hkd'), // Hong Kong Dollar
-    HUF: /** @type {'huf'} */ ('huf'), // Hungarian Forint
-    IDR: /** @type {'idr'} */ ('idr'), // Indonesian Rupiah
-    ILS: /** @type {'ils'} */ ('ils'), // Israeli New Shekel
-    INR: /** @type {'inr'} */ ('inr'), // Indian Rupee
-    JPY: /** @type {'jpy'} */ ('jpy'), // Japanese Yen
-    KRW: /** @type {'krw'} */ ('krw'), // South Korean Won
-    KWD: /** @type {'kwd'} */ ('kwd'), // Kuwaiti Dinar
-    LKR: /** @type {'lkr'} */ ('lkr'), // Sri Lankan Rupee
-    MMK: /** @type {'mmk'} */ ('mmk'), // Burmese Kyat
-    MXN: /** @type {'mxn'} */ ('mxn'), // Mexican Peso
-    MYR: /** @type {'myr'} */ ('myr'), // Malaysian Ringgit
-    NGN: /** @type {'ngn'} */ ('ngn'), // Nigerian Naira
-    NOK: /** @type {'nok'} */ ('nok'), // Norwegian Krone
-    NZD: /** @type {'nzd'} */ ('nzd'), // New Zealand Dollar
-    PHP: /** @type {'php'} */ ('php'), // Philippine Peso
-    PKR: /** @type {'pkr'} */ ('pkr'), // Pakistani Rupee
-    PLN: /** @type {'pln'} */ ('pln'), // Poland Złoty
-    RUB: /** @type {'rub'} */ ('rub'), // Russian Ruble
-    SAR: /** @type {'sar'} */ ('sar'), // Saudi Riyal
-    SEK: /** @type {'sek'} */ ('sek'), // Swedish Krona
-    SGD: /** @type {'sgd'} */ ('sgd'), // Singapore Dollar
-    THB: /** @type {'thb'} */ ('thb'), // Thai Baht
-    TRY: /** @type {'try'} */ ('try'), // Turkish Lira
-    TWD: /** @type {'twd'} */ ('twd'), // New Taiwan Dollar
-    UAH: /** @type {'uah'} */ ('uah'), // Ukrainian Hryvnia
-    USD: /** @type {'usd'} */ ('usd'), // United States Dollar
-    // VEF: /** @type {'vef'} */ ('vef'), // Discontinued Venezuelan Bolívar Fuerte replaced by VES. Rates are off.
-    VND: /** @type {'vnd'} */ ('vnd'), // Vietnamese Đồng
-    ZAR: /** @type {'zar'} */ ('zar'), // South African Rand
-};
+FiatApi.Provider = FiatApi.SupportedProvider.CoinGecko;
 
-/**
- * @readonly
- * Coingecko api url. Note that the origin must be whitelisted in the csp.
- */
-FiatApi.API_URL = 'https://api.coingecko.com/api/v3';
+switch (FiatApi.Provider) { // eslint-disable-line default-case, -- no default to let ts warn us on missing providers
+    case FiatApi.SupportedProvider.CoinGecko: {
+        /**
+         * @readonly
+         * @enum { 'nim' | 'btc' }
+         * Crypto currencies supported by the coingecko api that are currently of interest to us.
+         */
+        FiatApi.SupportedCryptoCurrency = {
+            NIM: /** @type {'nim'} */ ('nim'),
+            BTC: /** @type {'btc'} */ ('btc'),
+        };
 
-/**
- * @readonly
- * Crypto currency tickers mapped to coingecko coin ids.
- */
-FiatApi.COINGECKO_COIN_IDS = {
-    [FiatApi.SupportedCryptoCurrency.NIM]: 'nimiq-2',
-    [FiatApi.SupportedCryptoCurrency.BTC]: 'bitcoin',
-};
+        /**
+         * @readonly
+         * @enum {'aed' | 'ars' | 'aud' | 'bdt' | 'bhd' | 'bmd' | 'brl' | 'cad' | 'chf' | 'clp' | 'cny' | 'czk' | 'dkk'
+         *     | 'eur' | 'gbp' | 'gel' | 'hkd' | 'huf' | 'idr' | 'ils' | 'inr' | 'jpy' | 'krw' | 'kwd' | 'lkr' | 'mmk'
+         *     | 'mxn' | 'myr' | 'ngn' | 'nok' | 'nzd' | 'php' | 'pkr' | 'pln' | 'rub' | 'sar' | 'sek' | 'sgd' | 'thb'
+         *     | 'try' | 'twd' | 'uah' | 'usd' | 'vnd' | 'zar'}
+         * Fiat currencies supported by the coingecko api. Note that coingecko supports more vs_currencies (see
+         * https://api.coingecko.com/api/v3/simple/supported_vs_currencies) but also includes crypto currencies and
+         * ounces of gold amongst others that are not fiat currencies. See FiatApi in @nimiq/utils for how this list was
+         * assembled.
+         */
+        FiatApi.SupportedFiatCurrency = {
+            AED: /** @type {'aed'} */ ('aed'), // Arab Emirates Dirham
+            ARS: /** @type {'ars'} */ ('ars'), // Argentine Peso
+            AUD: /** @type {'aud'} */ ('aud'), // Australian Dollar
+            BDT: /** @type {'bdt'} */ ('bdt'), // Bangladeshi Taka
+            BHD: /** @type {'bhd'} */ ('bhd'), // Bahraini Dinar
+            BMD: /** @type {'bmd'} */ ('bmd'), // Bermudan Dollar
+            BRL: /** @type {'brl'} */ ('brl'), // Brazilian Real
+            CAD: /** @type {'cad'} */ ('cad'), // Canadian Dollar
+            CHF: /** @type {'chf'} */ ('chf'), // Swiss Franc
+            CLP: /** @type {'clp'} */ ('clp'), // Chilean Peso
+            CNY: /** @type {'cny'} */ ('cny'), // Chinese Yuan
+            CZK: /** @type {'czk'} */ ('czk'), // Czech Koruna
+            DKK: /** @type {'dkk'} */ ('dkk'), // Danish Krone
+            EUR: /** @type {'eur'} */ ('eur'), // Euro
+            GBP: /** @type {'gbp'} */ ('gbp'), // British Pound
+            GEL: /** @type {'gel'} */ ('gel'), // Georgian Lari
+            HKD: /** @type {'hkd'} */ ('hkd'), // Hong Kong Dollar
+            HUF: /** @type {'huf'} */ ('huf'), // Hungarian Forint
+            IDR: /** @type {'idr'} */ ('idr'), // Indonesian Rupiah
+            ILS: /** @type {'ils'} */ ('ils'), // Israeli New Shekel
+            INR: /** @type {'inr'} */ ('inr'), // Indian Rupee
+            JPY: /** @type {'jpy'} */ ('jpy'), // Japanese Yen
+            KRW: /** @type {'krw'} */ ('krw'), // South Korean Won
+            KWD: /** @type {'kwd'} */ ('kwd'), // Kuwaiti Dinar
+            LKR: /** @type {'lkr'} */ ('lkr'), // Sri Lankan Rupee
+            MMK: /** @type {'mmk'} */ ('mmk'), // Burmese Kyat
+            MXN: /** @type {'mxn'} */ ('mxn'), // Mexican Peso
+            MYR: /** @type {'myr'} */ ('myr'), // Malaysian Ringgit
+            NGN: /** @type {'ngn'} */ ('ngn'), // Nigerian Naira
+            NOK: /** @type {'nok'} */ ('nok'), // Norwegian Krone
+            NZD: /** @type {'nzd'} */ ('nzd'), // New Zealand Dollar
+            PHP: /** @type {'php'} */ ('php'), // Philippine Peso
+            PKR: /** @type {'pkr'} */ ('pkr'), // Pakistani Rupee
+            PLN: /** @type {'pln'} */ ('pln'), // Poland Złoty
+            RUB: /** @type {'rub'} */ ('rub'), // Russian Ruble
+            SAR: /** @type {'sar'} */ ('sar'), // Saudi Riyal
+            SEK: /** @type {'sek'} */ ('sek'), // Swedish Krona
+            SGD: /** @type {'sgd'} */ ('sgd'), // Singapore Dollar
+            THB: /** @type {'thb'} */ ('thb'), // Thai Baht
+            TRY: /** @type {'try'} */ ('try'), // Turkish Lira
+            TWD: /** @type {'twd'} */ ('twd'), // New Taiwan Dollar
+            UAH: /** @type {'uah'} */ ('uah'), // Ukrainian Hryvnia
+            USD: /** @type {'usd'} */ ('usd'), // United States Dollar
+            // VEF: /** @type {'vef'} */ ('vef'), // Retired Venezuelan Bolívar Fuerte replaced by VES. Rates are off.
+            VND: /** @type {'vnd'} */ ('vnd'), // Vietnamese Đồng
+            ZAR: /** @type {'zar'} */ ('zar'), // South African Rand
+        };
+
+        /**
+         * @readonly
+         * Coingecko api url. Note that the origin must be whitelisted in the csp.
+         */
+        FiatApi.API_URL = 'https://api.coingecko.com/api/v3';
+
+        /**
+         * @readonly
+         * Crypto currency tickers mapped to coingecko coin ids.
+         */
+        FiatApi.COINGECKO_COIN_IDS = {
+            [FiatApi.SupportedCryptoCurrency.NIM]: 'nimiq-2',
+            [FiatApi.SupportedCryptoCurrency.BTC]: 'bitcoin',
+        };
+
+        break;
+    }
+}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq bietet diesen Service kostenfrei an.",
     "payment-info-line-total": "Gesamt",
     "payment-info-line-network-fee": "Netzwerkgebühr",
-    "payment-info-line-paying-more": "Du zahlst etwa %RATE_DEVIATION% mehr als zum aktuellen Wechselkurs (coingecko.com).",
-    "payment-info-line-paying-less": "Du zahlst etwa %RATE_DEVIATION% weniger als zum aktuellen Wechselkurs (coingecko.com).",
-    "payment-info-line-actual-discount": "Dein tatsächlicher Rabatt beträgt etwa %RATE_DEVIATION% zum aktuellen Wechselkurs (coingecko.com).",
+    "payment-info-line-paying-more": "Du zahlst etwa {formattedRateDeviation} mehr als zum aktuellen Wechselkurs ({provider}).",
+    "payment-info-line-paying-less": "Du zahlst etwa {formattedRateDeviation} weniger als zum aktuellen Wechselkurs ({provider}).",
+    "payment-info-line-actual-discount": "Dein tatsächlicher Rabatt beträgt etwa {formattedRateDeviation} zum aktuellen Wechselkurs ({provider}).",
 
     "timer-expiry": "Angebot endet in",
     "timer-second": "Sekunde",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq provides this service free of charge.",
     "payment-info-line-total": "Total",
     "payment-info-line-network-fee": "network fee",
-    "payment-info-line-paying-more": "You are paying approx. %RATE_DEVIATION% more than at the current market rate (coingecko.com).",
-    "payment-info-line-paying-less": "You are paying approx. %RATE_DEVIATION% less than at the current market rate (coingecko.com).",
-    "payment-info-line-actual-discount": "Your actual discount is approx. %RATE_DEVIATION% compared to the current market rate (coingecko.com).",
+    "payment-info-line-paying-more": "You are paying approx. {formattedRateDeviation} more than at the current market rate ({provider}).",
+    "payment-info-line-paying-less": "You are paying approx. {formattedRateDeviation} less than at the current market rate ({provider}).",
+    "payment-info-line-actual-discount": "Your actual discount is approx. {formattedRateDeviation} compared to the current market rate ({provider}).",
 
     "timer-expiry": "This offer expires in",
     "timer-second": "second",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq provee este servicio libre de costo",
     "payment-info-line-total": "Total",
     "payment-info-line-network-fee": "cuota de red",
-    "payment-info-line-paying-more": "Usted esta pagando aproximadamente. %RATE_DEVIATION% más que la taza del mercado actual  (coingecko.com).",
-    "payment-info-line-paying-less": "Usted esta pagando aproximadamente. %RATE_DEVIATION% menos que la taza del mercado actual (coingecko.com).",
-    "payment-info-line-actual-discount": "Su descuento actual es aproximadamente %RATE_DEVIATION% en comparación de la taza del mercado actual (coingecko.com).",
+    "payment-info-line-paying-more": "Usted esta pagando aproximadamente. {formattedRateDeviation} más que la taza del mercado actual  ({provider}).",
+    "payment-info-line-paying-less": "Usted esta pagando aproximadamente. {formattedRateDeviation} menos que la taza del mercado actual ({provider}).",
+    "payment-info-line-actual-discount": "Su descuento actual es aproximadamente {formattedRateDeviation} en comparación de la taza del mercado actual ({provider}).",
 
     "timer-expiry": "La oferta expira en",
     "timer-second": "segundo",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq fournit ce service gratuitement.",
     "payment-info-line-total": "Total",
     "payment-info-line-network-fee": "frais du réseau",
-    "payment-info-line-paying-more": "Vous payez env. %RATE_DEVIATION% de plus que le taux actuel du marché (coingecko.com).",
-    "payment-info-line-paying-less": "Vous payez env. %RATE_DEVIATION% de moins que le taux actuel du marché (coingecko.com).",
-    "payment-info-line-actual-discount": "Votre remise réelle est d'env. %RATE_DEVIATION% par rapport au taux actuel du marché (coingecko.com).",
+    "payment-info-line-paying-more": "Vous payez env. {formattedRateDeviation} de plus que le taux actuel du marché ({provider}).",
+    "payment-info-line-paying-less": "Vous payez env. {formattedRateDeviation} de moins que le taux actuel du marché ({provider}).",
+    "payment-info-line-actual-discount": "Votre remise réelle est d'env. {formattedRateDeviation} par rapport au taux actuel du marché ({provider}).",
 
     "timer-expiry": "Cette offre expire dans",
     "timer-second": "seconde",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq biedt deze service gratis aan.",
     "payment-info-line-total": "Totaal",
     "payment-info-line-network-fee": "netwerkkosten",
-    "payment-info-line-paying-more": "U betaalt ongeveer %RATE_DEVIATION% meer dan de huidige marktkoers (coingecko.com).",
-    "payment-info-line-paying-less": "Je betaalt ongeveer %RATE_DEVIATION% minder dan het huidige markttarief (coingecko.com).",
-    "payment-info-line-actual-discount": "Je daadwerkelijke korting is ca. %RATE_DEVIATION% in vergelijking met het huidige markttarief (coingecko.com).",
+    "payment-info-line-paying-more": "U betaalt ongeveer {formattedRateDeviation} meer dan de huidige marktkoers ({provider}).",
+    "payment-info-line-paying-less": "Je betaalt ongeveer {formattedRateDeviation} minder dan het huidige markttarief ({provider}).",
+    "payment-info-line-actual-discount": "Je daadwerkelijke korting is ca. {formattedRateDeviation} in vergelijking met het huidige markttarief ({provider}).",
 
     "timer-expiry": "Deze aanbieding vervalt over",
     "timer-second": "seconde",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "A Nimiq oferece este serviço.",
     "payment-info-line-total": "Total",
     "payment-info-line-network-fee": "taxa de rede",
-    "payment-info-line-paying-more": "Está a pagar aproximadamente %RATE_DEVIATION% a mais do que a taxa atual de mercado (coingecko.com).",
-    "payment-info-line-paying-less": "Está a pagar aproximadamente %RATE_DEVIATION% a menos do que a taxa atual de mercado (coingecko.com).",
-    "payment-info-line-actual-discount": "O seu desconto atual é aproximadamente de %RATE_DEVIATION% comparado com a taxa atual de mercado (coingecko.com).",
+    "payment-info-line-paying-more": "Está a pagar aproximadamente {formattedRateDeviation} a mais do que a taxa atual de mercado ({provider}).",
+    "payment-info-line-paying-less": "Está a pagar aproximadamente {formattedRateDeviation} a menos do que a taxa atual de mercado ({provider}).",
+    "payment-info-line-actual-discount": "O seu desconto atual é aproximadamente de {formattedRateDeviation} comparado com a taxa atual de mercado ({provider}).",
 
     "timer-expiry": "Esta oferta expira em",
     "timer-second": "segundo",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq предоставляет данный сервис бесплатно.",
     "payment-info-line-total": "Итого",
     "payment-info-line-network-fee": "комиссия сети",
-    "payment-info-line-paying-more": "Вы платите приблизительно на %RATE_DEVIATION% больше, чем по текущему рыночному курсу (coingecko.com).",
-    "payment-info-line-paying-less": "Вы платите приблизительно на %RATE_DEVIATION% меньше, чем по текущему рыночному курсу (coingecko.com).",
-    "payment-info-line-actual-discount": "Ваша фактическая скидка составляет приблизительно %RATE_DEVIATION% по сравнению с текущим рыночным курсом (coingecko.com).",
+    "payment-info-line-paying-more": "Вы платите приблизительно на {formattedRateDeviation} больше, чем по текущему рыночному курсу ({provider}).",
+    "payment-info-line-paying-less": "Вы платите приблизительно на {formattedRateDeviation} меньше, чем по текущему рыночному курсу ({provider}).",
+    "payment-info-line-actual-discount": "Ваша фактическая скидка составляет приблизительно {formattedRateDeviation} по сравнению с текущим рыночным курсом ({provider}).",
 
     "timer-expiry": "Предложение истекает через",
     "timer-second": "секунда",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Німік надає цю послугу безплатно.",
     "payment-info-line-total": "сума",
     "payment-info-line-network-fee": "комісія мережі",
-    "payment-info-line-paying-more": "У вас знижка приблизно %RATE_DEVIATION% більше в порівнянні з поточним ринковим курсом (coingecko.com).",
-    "payment-info-line-paying-less": "Ви платите приблизно %RATE_DEVIATION% менше в порівнянні з поточним ринковим курсом (coingecko.com).",
-    "payment-info-line-actual-discount": "У вас знижка приблизно %RATE_DEVIATION% в порівнянні з поточним ринковим курсом (coingecko.com).",
+    "payment-info-line-paying-more": "У вас знижка приблизно {formattedRateDeviation} більше в порівнянні з поточним ринковим курсом ({provider}).",
+    "payment-info-line-paying-less": "Ви платите приблизно {formattedRateDeviation} менше в порівнянні з поточним ринковим курсом ({provider}).",
+    "payment-info-line-actual-discount": "У вас знижка приблизно {formattedRateDeviation} в порівнянні з поточним ринковим курсом ({provider}).",
 
     "timer-expiry": "Ця пропозиція закінчується через",
     "timer-second": "секунду",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -112,9 +112,9 @@
     "payment-info-line-free-service": "Nimiq免费提供这项服务。",
     "payment-info-line-total": "总额",
     "payment-info-line-network-fee": "网络费",
-    "payment-info-line-paying-more": "你需要比当前市场汇率(coingecko.com)多支付大约%RATE_DEVIATION%。",
-    "payment-info-line-paying-less": "你需要比当前市场汇率(coingecko.com)少支付大约%RATE_DEVIATION%。",
-    "payment-info-line-actual-discount": "与当前市场汇率(coingecko.com)相比，你的实际折扣约为%RATE_DEVIATION%。",
+    "payment-info-line-paying-more": "你需要比当前市场汇率({provider})多支付大约{formattedRateDeviation}。",
+    "payment-info-line-paying-less": "你需要比当前市场汇率({provider})少支付大约{formattedRateDeviation}。",
+    "payment-info-line-actual-discount": "与当前市场汇率({provider})相比，你的实际折扣约为{formattedRateDeviation}。",
 
     "timer-expiry": "此报价在以下时间到期",
     "timer-second": "秒",


### PR DESCRIPTION
- Switch back to the public CoinGecko API as we shut down our custom API endpoint. The public API is accessible from the keyguard domain with no issues and the usage limits are sufficient for the Keyguard's needs.
- Update the list of currencies supported by CoinGecko.
- Refactor FiatApi and translations mentioning the provider, to possibly support other providers in the future. Initially, I thought this would be more work, as I thought the implementation would be close to the one in `FiatApi` in `@nimiq/utils`, with dynamic providers, currency support depending on the chosen provider, type generics for the chosen provider etc. However, in the Keyguard, it can be quite a bit easier, as the provider can be considered a fixed value. Based on that value (which currently is only CoinGecko), I'm simply setting, for example, the appropriate list of supported currencies and the api endpoint, also as fixed values. Typescript seems to be happy with this. Maybe a more modern typescript version might complain, or if a second provider is actually added, but in that case all code and types for the inactive provider can simply be commented out to circumvent such issues.
- This PR is probably easier reviewed with whitespace changes ignored.