### PR TITLE
Multisig: Use AES for RSA key encryption

### DIFF
--- a/src/request/change-password/index.html
+++ b/src/request/change-password/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/connect/index.html
+++ b/src/request/connect/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -37,7 +38,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/derive-btc-xpub/index.html
+++ b/src/request/derive-btc-xpub/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/derive-polygon-address/index.html
+++ b/src/request/derive-polygon-address/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/iframe/index.html
+++ b/src/request/iframe/index.html
@@ -15,6 +15,7 @@
         <script defer manual src="../../config/config.local.js"></script>
 
         <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+        <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
         <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
         <script defer bundle-common src="../../lib/KeyStore.js"></script>
         <script defer bundle-common src="../../lib/Key.js"></script>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -41,7 +42,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-btc-transaction/index.html
+++ b/src/request/sign-btc-transaction/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -18,6 +18,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -38,7 +39,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-multisig-transaction/index.html
+++ b/src/request/sign-multisig-transaction/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-polygon-transaction/index.html
+++ b/src/request/sign-polygon-transaction/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-staking/index.html
+++ b/src/request/sign-staking/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-swap/index.html
+++ b/src/request/sign-swap/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -41,7 +42,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -19,6 +19,7 @@
     <script defer manual src="../../config/config.local.js"></script>
 
     <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+    <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
@@ -39,7 +40,6 @@
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
-    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>
 

--- a/src/request/swap-iframe/index.html
+++ b/src/request/swap-iframe/index.html
@@ -15,6 +15,7 @@
         <script defer manual src="../../config/config.local.js"></script>
 
         <script defer bundle-common src="../../lib/JsonUtils.js"></script>
+        <script defer bundle-common src="../../lib/Utf8Tools.js"></script>
         <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
         <script defer bundle-common src="../../lib/KeyStore.js"></script>
         <script defer bundle-common src="../../lib/Key.js"></script>
@@ -41,7 +42,6 @@
         <script defer src="../../lib/swap/HtlcUtils.js"></script>
         <script defer src="../../lib/polygon/OpenGSN.js"></script>
         <script defer src="../../lib/swap/OasisSettlementInstructionUtils.js"></script>
-        <script defer src="../../lib/Utf8Tools.js"></script>
 
         <script defer src="SwapIFrameApi.js"></script>
         <script defer src="index.js"></script>

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -34,18 +34,19 @@ type AccountRecord = AccountInfo & {
 
 type RsaKeyParams = KeyguardRequest.RsaKeyParams;
 
-type RsaKeyPairExport = {
-    privateKey: Uint8Array
-    publicKey: Uint8Array
+type RsaKeyPair = {
+    privateKey: CryptoKey
+    publicKey: CryptoKey
     keyParams: RsaKeyParams
 }
 
-type RsaKeyPairEncryptedExport = Transform<RsaKeyPairExport, 'privateKey', {
+type RsaKeyPairEncryptedExport = Transform<RsaKeyPair, 'privateKey' | 'publicKey', {
     privateKey: {
-        salt: Uint8Array,
+        salt: Uint8Array, // HKDF salt
         iv: Uint8Array, // AES initialization vector
         encrypted: Uint8Array,
     },
+    publicKey: Uint8Array,
 }>;
 
 type KeyRecord = {

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -43,8 +43,8 @@ type RsaKeyPairExport = {
 type RsaKeyPairEncryptedExport = Transform<RsaKeyPairExport, 'privateKey', {
     privateKey: {
         salt: Uint8Array,
-        kdfRounds: number,
-        encrypted: Uint8Array, // key + checksum
+        iv: Uint8Array, // AES initialization vector
+        encrypted: Uint8Array,
     },
 }>;
 


### PR DESCRIPTION
An alternative approach to encrypting the RSA private key on storage, which is used in the multisig feature.
This alternative approach has a couple of advantages to the [one previously taken](https://github.com/nimiq/keyguard/pull/524/commits/8213c40b2616e9e58a5d5a22a24d271a83ded576):
- it uses AES encryption via browser native crypto APIs
- RSA keys are represented as native `CryptoKey`s at runtime
- the implementation is more versatile and the AES encryption can easily be used for other use cases in the future.