### PR TITLE
Multisig-fixes Fixes

### DIFF
--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -613,7 +613,6 @@ export type ListLegacyResult = LegacyKeyInfoObject[];
 export type SignTransactionResult = SignatureResult & {
     serializedTx: Uint8Array,
 };
-export type SignMultisigTransactionResult = SignatureResult;
 export type SignStakingResult = SignatureResult & {
     transaction: Uint8Array,
 };
@@ -651,7 +650,6 @@ export type RedirectResult
     | SignatureResult
     | ConnectResult
     | SignTransactionResult
-    | SignMultisigTransactionResult
     | SignStakingResult[]
     | SignedBitcoinTransaction
     | SignedPolygonTransaction
@@ -667,7 +665,7 @@ export type Result = RedirectResult | IFrameResult;
 export type ResultType<T extends RedirectRequest> =
     T extends Is<T, SignMessageRequest> ? SignatureResult :
     T extends Is<T, SignTransactionRequest> ? SignTransactionResult :
-    T extends Is<T, SignMultisigTransactionRequest> ? SignMultisigTransactionResult :
+    T extends Is<T, SignMultisigTransactionRequest> ? SignatureResult :
     T extends Is<T, SignStakingRequest> ? SignStakingResult[] :
     T extends Is<T, ConnectRequest> ? ConnectResult :
     T extends Is<T, DeriveAddressRequest> ? DerivedAddress[] :
@@ -684,7 +682,7 @@ export type ResultType<T extends RedirectRequest> =
 export type ResultByCommand<T extends KeyguardCommand> =
     T extends KeyguardCommand.SIGN_MESSAGE ? SignatureResult :
     T extends KeyguardCommand.SIGN_TRANSACTION ? SignTransactionResult :
-    T extends KeyguardCommand.SIGN_MULTISIG_TRANSACTION ? SignMultisigTransactionResult :
+    T extends KeyguardCommand.SIGN_MULTISIG_TRANSACTION ? SignatureResult :
     T extends KeyguardCommand.SIGN_STAKING ? SignStakingResult[] :
     T extends KeyguardCommand.CONNECT_ACCOUNT ? ConnectResult :
     T extends KeyguardCommand.DERIVE_ADDRESS ? DerivedAddress[] :

--- a/demos/ConnectAccount.html
+++ b/demos/ConnectAccount.html
@@ -35,14 +35,14 @@
 
     <div class="row">
         <label>Challenge</label>
-		<input id="challenge" value="some random characters">
+        <input id="challenge" value="some random characters">
     </div>
 
     <div class="row">
         <label>Permissions</label>
-		<label>
-			<input type="checkbox" id="permission-sign-multisig-transaction" checked> sign-multisig-transaction
-		</label>
+        <label>
+            <input type="checkbox" id="permission-sign-multisig-transaction" checked> sign-multisig-transaction
+        </label>
     </div>
 
     <!-- <br><button id="redirect" type="button" class="small" disabled>Connect Account (redirect)</button> -->
@@ -54,23 +54,23 @@
 <script>
     window.addEventListener('load', async () => {
         await Nimiq.default();
-	    loadAccounts();
+        loadAccounts();
     });
 
     const accountSelector = document.querySelector('#account');
 
-	async function loadAccounts() {
-		/** @type {KeyInfo[]} */
-		const keyInfos = await KeyStore.instance.list();
-		const dom = document.createDocumentFragment();
-		for (const keyInfo of keyInfos) {
-			const option = document.createElement('option');
-			option.value = keyInfo.id;
-			option.textContent = keyInfo.defaultAddress.toUserFriendlyAddress();
-			dom.appendChild(option);
-		}
-		accountSelector.appendChild(dom);
-	}
+    async function loadAccounts() {
+        /** @type {KeyInfo[]} */
+        const keyInfos = await KeyStore.instance.list();
+        const dom = document.createDocumentFragment();
+        for (const keyInfo of keyInfos) {
+            const option = document.createElement('option');
+            option.value = keyInfo.id;
+            option.textContent = keyInfo.defaultAddress.toUserFriendlyAddress();
+            dom.appendChild(option);
+        }
+        accountSelector.appendChild(dom);
+    }
 
     document.querySelector('button#popup').addEventListener('click', async () => {
         connectAccountPopup(await generateRequest());
@@ -79,7 +79,7 @@
     async function generateRequest() {
         const keyId = accountSelector.value;
         const challenge = document.querySelector('#challenge').value;
-		const permissions = ['sign-multisig-transaction']; // TODO
+        const permissions = ['sign-multisig-transaction']; // TODO
 
         const request = {
             appName: 'Nimiq Multisig',
@@ -88,9 +88,9 @@
             keyLabel: 'Some Account',
 
             appLogoUrl: `${window.location.origin}/demos/multisig-logo.svg`,
-			permissions,
+            permissions,
             requestedKeyPaths: [`m/44'/242'/0'/0'`],
-			challenge,
+            challenge,
         };
 
         return request;

--- a/demos/ConnectAccount.html
+++ b/demos/ConnectAccount.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>SignTransaction | Keyguard Demo</title>
     <link href="../src/nimiq-style.css" rel="stylesheet">
-    <script src="../node_modules/@nimiq/core-web/web-offline.js"></script>
+    <script type="module" src="../src/lib/AlbatrossWasm.mjs"></script>
     <script src="../src/lib/KeyInfo.js"></script>
     <script src="../src/lib/KeyStore.js"></script>
     <script src="../node_modules/@nimiq/rpc/dist/rpc.umd.js"></script>
@@ -14,7 +14,7 @@
             margin: 1rem 0;
         }
 
-        label, input {
+        label {
             display: block;
             margin: 5px;
         }
@@ -52,6 +52,11 @@
 </form>
 
 <script>
+    window.addEventListener('load', async () => {
+        await Nimiq.default();
+	    loadAccounts();
+    });
+
     const accountSelector = document.querySelector('#account');
 
 	async function loadAccounts() {
@@ -66,7 +71,6 @@
 		}
 		accountSelector.appendChild(dom);
 	}
-	loadAccounts();
 
     document.querySelector('button#popup').addEventListener('click', async () => {
         connectAccountPopup(await generateRequest());

--- a/demos/ConnectAccount.html
+++ b/demos/ConnectAccount.html
@@ -51,11 +51,8 @@
     <p id="result"></p>
 </form>
 
-<script>
-    window.addEventListener('load', async () => {
-        await Nimiq.default();
-        loadAccounts();
-    });
+<script type="module">
+    await Nimiq.default();
 
     const accountSelector = document.querySelector('#account');
 
@@ -71,6 +68,7 @@
         }
         accountSelector.appendChild(dom);
     }
+    loadAccounts();
 
     document.querySelector('button#popup').addEventListener('click', async () => {
         connectAccountPopup(await generateRequest());

--- a/demos/RSAKeys.html
+++ b/demos/RSAKeys.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>RSA Keys | Keyguard Demo</title>
     <link href="../src/nimiq-style.css" rel="stylesheet">
-    <script src="../node_modules/@nimiq/core-web/web-offline.js"></script>
+    <script type="module" src="../src/lib/AlbatrossWasm.mjs"></script>
     <script src="../src/lib/Constants.js"></script>
     <!-- <script src="../src/lib/Key.js"></script> -->
     <script src="../src/lib/KeyStore.js"></script>
@@ -77,6 +77,10 @@
 	</p>
 
 	<script>
+		window.addEventListener('load', async () => {
+			await Nimiq.default();
+		});
+
 		/** @type {HTMLButtonElement} */
 		const $newEntropy = document.querySelector('#new-entropy');
 		/** @type {HTMLTextAreaElement} */
@@ -105,16 +109,14 @@
 			$generate.disabled = true;
 
 			try {
-				await Nimiq.WasmHelper.doImport();
-
 				// Extend 32-byte entropy into 1024-byte seed
 				const entropyBuffer = Nimiq.BufferUtils.fromHex($entropy.value);
-				const seed = Nimiq.BufferUtils.toUtf8(Nimiq.CryptoUtils.computePBKDF2sha512(
+				const seed = Nimiq.CryptoUtils.computePBKDF2sha512(
 					entropyBuffer,
 					Nimiq.PublicKey.derive(Nimiq.PrivateKey.deserialize(entropyBuffer)).toAddress().serialize(),
 					1024, // Iterations
 					1024, // Output size
-				));
+				);
 				const keySize = parseInt($keysize.value);
 				const iframe = $iframe.contentWindow;
 

--- a/demos/RSAKeys.html
+++ b/demos/RSAKeys.html
@@ -76,10 +76,8 @@
         <textarea id="public-key" class="key" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
     </p>
 
-    <script>
-        window.addEventListener('load', async () => {
-            await Nimiq.default();
-        });
+    <script type="module">
+        await Nimiq.default();
 
         /** @type {HTMLButtonElement} */
         const $newEntropy = document.querySelector('#new-entropy');

--- a/demos/RSAKeys.html
+++ b/demos/RSAKeys.html
@@ -21,23 +21,23 @@
             margin: 5px;
         }
 
-		textarea {
-			width: 300px;
-			height: 100px;
-		}
+        textarea {
+            width: 300px;
+            height: 100px;
+        }
 
-		textarea.key {
-			width: 500px;
-			height: 400px;
-		}
+        textarea.key {
+            width: 500px;
+            height: 400px;
+        }
 
-		textarea.key.same {
-			background: lightgreen;
-		}
+        textarea.key.same {
+            background: lightgreen;
+        }
 
-		iframe {
-			height: 40px;
-		}
+        iframe {
+            height: 40px;
+        }
 
         #result {
             max-width: 900px;
@@ -46,141 +46,141 @@
     </style>
 </head>
 <body>
-	<h1>RSA Keys</h1>
+    <h1>RSA Keys</h1>
 
-	<p>
-		<label>Entropy: <button id="new-entropy">New</button></label>
-		<textarea id="entropy">cd52908f241166411ca945ea4254daea7cc63dd7f3044ea2f04d7685e31bd397</textarea>
-	</p>
+    <p>
+        <label>Entropy: <button id="new-entropy">New</button></label>
+        <textarea id="entropy">cd52908f241166411ca945ea4254daea7cc63dd7f3044ea2f04d7685e31bd397</textarea>
+    </p>
 
-	<p>
-		<label>Key Size:</label>
-		<select id="key-size">
-			<option>1024 (unsafe)</option>
-			<option selected>2048 (fast)</option>
-			<option>4096 (safe)</option>
-		</select>
-	</p>
+    <p>
+        <label>Key Size:</label>
+        <select id="key-size">
+            <option>1024 (unsafe)</option>
+            <option selected>2048 (fast)</option>
+            <option>4096 (safe)</option>
+        </select>
+    </p>
 
-	<p>
-		<label>Sandboxed Iframe:</label>
-		<iframe src="/src/lib/rsa/sandboxed/RSAKeysIframe.html" sandbox="allow-scripts" id="iframe"></iframe>
-	</p>
+    <p>
+        <label>Sandboxed Iframe:</label>
+        <iframe src="/src/lib/rsa/sandboxed/RSAKeysIframe.html" sandbox="allow-scripts" id="iframe"></iframe>
+    </p>
 
-	<p>
-		<button id="generate">Generate RSA Key</button>
-	</p>
+    <p>
+        <button id="generate">Generate RSA Key</button>
+    </p>
 
-	<p>
-		<textarea id="private-key" class="key" placeholder="-----BEGIN RSA PRIVATE KEY-----"></textarea>
-		<textarea id="public-key" class="key" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
-	</p>
+    <p>
+        <textarea id="private-key" class="key" placeholder="-----BEGIN RSA PRIVATE KEY-----"></textarea>
+        <textarea id="public-key" class="key" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
+    </p>
 
-	<script>
-		window.addEventListener('load', async () => {
-			await Nimiq.default();
-		});
+    <script>
+        window.addEventListener('load', async () => {
+            await Nimiq.default();
+        });
 
-		/** @type {HTMLButtonElement} */
-		const $newEntropy = document.querySelector('#new-entropy');
-		/** @type {HTMLTextAreaElement} */
-		const $entropy = document.querySelector('#entropy');
-		/** @type {HTMLSelectElement} */
-		const $keysize = document.querySelector('#key-size');
-		/** @type {HTMLIFrameElement} */
-		const $iframe = document.querySelector('#iframe');
-		/** @type {HTMLButtonElement} */
-		const $generate = document.querySelector('#generate');
-		/** @type {HTMLTextAreaElement} */
-		const $privateKey = document.querySelector('#private-key');
-		/** @type {HTMLTextAreaElement} */
-		const $publicKey = document.querySelector('#public-key');
+        /** @type {HTMLButtonElement} */
+        const $newEntropy = document.querySelector('#new-entropy');
+        /** @type {HTMLTextAreaElement} */
+        const $entropy = document.querySelector('#entropy');
+        /** @type {HTMLSelectElement} */
+        const $keysize = document.querySelector('#key-size');
+        /** @type {HTMLIFrameElement} */
+        const $iframe = document.querySelector('#iframe');
+        /** @type {HTMLButtonElement} */
+        const $generate = document.querySelector('#generate');
+        /** @type {HTMLTextAreaElement} */
+        const $privateKey = document.querySelector('#private-key');
+        /** @type {HTMLTextAreaElement} */
+        const $publicKey = document.querySelector('#public-key');
 
-		let lastPrivatePEM = '';
-		let lastPublicPEM = '';
+        let lastPrivatePEM = '';
+        let lastPublicPEM = '';
 
-		$newEntropy.addEventListener('click', () => {
-			$entropy.value = Nimiq.Entropy.generate().toHex();
-		});
+        $newEntropy.addEventListener('click', () => {
+            $entropy.value = Nimiq.Entropy.generate().toHex();
+        });
 
-		$generate.addEventListener('click', async () => {
-			$privateKey.value = '';
-			$publicKey.value = '';
-			$generate.disabled = true;
+        $generate.addEventListener('click', async () => {
+            $privateKey.value = '';
+            $publicKey.value = '';
+            $generate.disabled = true;
 
-			try {
-				// Extend 32-byte entropy into 1024-byte seed
-				const entropyBuffer = Nimiq.BufferUtils.fromHex($entropy.value);
-				const seed = Nimiq.CryptoUtils.computePBKDF2sha512(
-					entropyBuffer,
-					Nimiq.PublicKey.derive(Nimiq.PrivateKey.deserialize(entropyBuffer)).toAddress().serialize(),
-					1024, // Iterations
-					1024, // Output size
-				);
-				const keySize = parseInt($keysize.value);
-				const iframe = $iframe.contentWindow;
+            try {
+                // Extend 32-byte entropy into 1024-byte seed
+                const entropyBuffer = Nimiq.BufferUtils.fromHex($entropy.value);
+                const seed = Nimiq.CryptoUtils.computePBKDF2sha512(
+                    entropyBuffer,
+                    Nimiq.PublicKey.derive(Nimiq.PrivateKey.deserialize(entropyBuffer)).toAddress().serialize(),
+                    1024, // Iterations
+                    1024, // Output size
+                );
+                const keySize = parseInt($keysize.value);
+                const iframe = $iframe.contentWindow;
 
-				iframe.postMessage({ command: 'generateKey', seed, keySize }, '*');
-			} catch (error) {
-				alert(error.message);
-				$generate.disabled = false;
-			}
-		});
+                iframe.postMessage({ command: 'generateKey', seed, keySize }, '*');
+            } catch (error) {
+                alert(error.message);
+                $generate.disabled = false;
+            }
+        });
 
-		window.addEventListener('message', async (event) => {
-			if (event.source === event.target) {
-				// console.log("Ignored same-window event:", event);
-				return;
-			}
+        window.addEventListener('message', async (event) => {
+            if (event.source === event.target) {
+                // console.log("Ignored same-window event:", event);
+                return;
+            }
 
-			/** @type {{privateKey: ArrayBuffer, publicKey: ArrayBuffer}} */
-			const data = event.data;
+            /** @type {{privateKey: ArrayBuffer, publicKey: ArrayBuffer}} */
+            const data = event.data;
             if (!('privateKey' in data) || !('publicKey' in data)) return;
-			console.log("MSG:", data);
+            console.log("MSG:", data);
 
-			const keyPair = {
-				privateKey: await window.crypto.subtle.importKey(
-					'pkcs8',
-					data.privateKey,
-					{
-						name: 'RSA-OAEP',
-						hash: 'SHA-256',
-					},
-					true,
-					['decrypt'],
-				),
-				publicKey: await window.crypto.subtle.importKey(
-					'spki',
-					data.publicKey,
-					{
-						name: 'RSA-OAEP',
-						hash: 'SHA-256',
-					},
-					true,
-					['encrypt'],
-				),
-			};
+            const keyPair = {
+                privateKey: await window.crypto.subtle.importKey(
+                    'pkcs8',
+                    data.privateKey,
+                    {
+                        name: 'RSA-OAEP',
+                        hash: 'SHA-256',
+                    },
+                    true,
+                    ['decrypt'],
+                ),
+                publicKey: await window.crypto.subtle.importKey(
+                    'spki',
+                    data.publicKey,
+                    {
+                        name: 'RSA-OAEP',
+                        hash: 'SHA-256',
+                    },
+                    true,
+                    ['encrypt'],
+                ),
+            };
 
-			const privateKeyExport = await window.crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
-			const publicKeyExport = await window.crypto.subtle.exportKey('spki', keyPair.publicKey);
+            const privateKeyExport = await window.crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+            const publicKeyExport = await window.crypto.subtle.exportKey('spki', keyPair.publicKey);
 
-			const privateB64 = Nimiq.BufferUtils.toBase64(new Nimiq.SerialBuffer(privateKeyExport));
-			const publicB64 = Nimiq.BufferUtils.toBase64(new Nimiq.SerialBuffer(publicKeyExport));
+            const privateB64 = Nimiq.BufferUtils.toBase64(new Nimiq.SerialBuffer(privateKeyExport));
+            const publicB64 = Nimiq.BufferUtils.toBase64(new Nimiq.SerialBuffer(publicKeyExport));
 
-			const privatePEM = `-----BEGIN RSA PRIVATE KEY-----\n${privateB64}\n-----END RSA PRIVATE KEY-----`;
-			const publicPEM = `-----BEGIN PUBLIC KEY-----\n${publicB64}\n-----END PUBLIC KEY-----`;
+            const privatePEM = `-----BEGIN RSA PRIVATE KEY-----\n${privateB64}\n-----END RSA PRIVATE KEY-----`;
+            const publicPEM = `-----BEGIN PUBLIC KEY-----\n${publicB64}\n-----END PUBLIC KEY-----`;
 
-			$privateKey.value = privatePEM;
-			$publicKey.value = publicPEM;
+            $privateKey.value = privatePEM;
+            $publicKey.value = publicPEM;
 
-			$privateKey.classList.toggle('same', privatePEM === lastPrivatePEM);
-			$publicKey.classList.toggle('same', publicPEM === lastPublicPEM);
+            $privateKey.classList.toggle('same', privatePEM === lastPrivatePEM);
+            $publicKey.classList.toggle('same', publicPEM === lastPublicPEM);
 
-			lastPrivatePEM = privatePEM;
-			lastPublicPEM = publicPEM;
+            lastPrivatePEM = privatePEM;
+            lastPublicPEM = publicPEM;
 
-			$generate.disabled = false;
-		});
-	</script>
+            $generate.disabled = false;
+        });
+    </script>
 </body>
 </html>

--- a/demos/SignMultisigTransaction.html
+++ b/demos/SignMultisigTransaction.html
@@ -102,10 +102,8 @@
     <p id="result"></p>
 </form>
 
-<script>
-    window.addEventListener('load', async () => {
-        await Nimiq.default();
-    });
+<script type="module">
+    await Nimiq.default();
 
     const layoutSelector = document.querySelector('#layout');
     const checkoutOnlyOptions = document.querySelectorAll('.checkout-only');

--- a/demos/SignMultisigTransaction.html
+++ b/demos/SignMultisigTransaction.html
@@ -2,13 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>SignTransaction | Keyguard Demo</title>
+    <title>SignMultisigTransaction | Keyguard Demo</title>
     <link href="../src/nimiq-style.css" rel="stylesheet">
-    <script src="../node_modules/@nimiq/core-web/web-offline.js"></script>
+    <script type="module" src="../src/lib/AlbatrossWasm.mjs"></script>
     <script src="../src/lib/Constants.js"></script>
     <script src="../src/lib/Key.js"></script>
     <script src="../src/lib/KeyStore.js"></script>
-    <script src="../src/lib/multisig/MerkleTreePatch.js"></script>
     <script src="../node_modules/@nimiq/rpc/dist/rpc.umd.js"></script>
 
     <style>
@@ -104,11 +103,9 @@
 </form>
 
 <script>
-    (async () => {
-        await Nimiq.WasmHelper.doImport();
-        Nimiq.GenesisConfig.test();
-        Nimiq.CryptoWorker.getInstanceAsync();
-    })();
+    window.addEventListener('load', async () => {
+        await Nimiq.default();
+    });
 
     const layoutSelector = document.querySelector('#layout');
     const checkoutOnlyOptions = document.querySelectorAll('.checkout-only');
@@ -150,7 +147,7 @@
         // Generate a random key and put it into the KeyStore.
         const secret = Nimiq.Entropy.generate();
         const key = new Key(secret);
-        const password = keyPassword ? Nimiq.BufferUtils.fromAscii(keyPassword) : undefined;
+        const password = keyPassword ? Nimiq.BufferUtils.fromUtf8(keyPassword) : undefined;
         const id = await KeyStore.instance.put(key, password);
 
         const path = "m/0'/0'";
@@ -185,12 +182,11 @@
 
             multisigConfig: {
                 publicKeys: publicKeys.map(key => key.serialize()),
-                numberOfSigners,
-                signerPublicKeys: publicKeys.slice(0, numberOfSigners).map(key => key.serialize()),
-                secret: {
-                    aggregatedSecret: Nimiq.PrivateKey.generate().serialize(), // Using random data
-                },
-                aggregatedCommitment: Nimiq.PrivateKey.generate().serialize(), // Using random data
+                signers: publicKeys.slice(0, numberOfSigners).map(key => ({
+                    publicKey: key.serialize(),
+                    commitments: new Array(2).fill(0).map(() => Nimiq.CommitmentPair.generate().commitment.serialize()), // Using random data
+                })),
+                secrets: new Array(2).fill(0).map(() => Nimiq.CommitmentPair.generate().secret.serialize()), // Using random data,
                 userName,
             }
         };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,6 +27,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // avoid calling runKeyguard and redirect page, only include local config
         exclude: [
+            'src/lib/rsa/sandboxed/*.js',
             'src/request/**/index.js',
             'src/redirect.js',
             'src/config/config.!(local).js',

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -35,7 +35,7 @@ class Key {
      * @param {RsaKeyParams} paramsB
      * @returns {boolean}
      */
-    static _areEqualRsaKeyParams(paramsA, paramsB) {
+    static _areRsaKeyParamsEqual(paramsA, paramsB) {
         return typeof paramsA === 'object' && typeof paramsB === 'object'
             && paramsA.kdf === paramsB.kdf
             && paramsA.iterations === paramsB.iterations
@@ -47,8 +47,8 @@ class Key {
      * @param {RsaKeyParams} params
      * @returns {boolean}
      */
-    static _areDefaultRsaKeyParams(params) {
-        return Key._areEqualRsaKeyParams(params, Key.defaultRsaKeyParams);
+    static _areRsaKeyParamsDefault(params) {
+        return Key._areRsaKeyParamsEqual(params, Key.defaultRsaKeyParams);
     }
 
     /**
@@ -219,7 +219,7 @@ class Key {
     async setRsaKeyPair(keyPair, persist) {
         this._rsaKeyPair = keyPair;
         // Persist if requested and the key params match the default params.
-        if (!persist || !Key._areDefaultRsaKeyParams(keyPair.keyParams)) return;
+        if (!persist || !Key._areRsaKeyParamsDefault(keyPair.keyParams)) return;
         await KeyStore.instance.setRsaKeypair(this, keyPair);
     }
 
@@ -257,9 +257,9 @@ class Key {
      */
     async _getOrComputeRsaKeyPair(keyParams) {
         const oldRsaKeyPair = this.getRsaKeyPairIfExists();
-        if (oldRsaKeyPair && Key._areEqualRsaKeyParams(keyParams, oldRsaKeyPair.keyParams)) return oldRsaKeyPair;
+        if (oldRsaKeyPair && Key._areRsaKeyParamsEqual(keyParams, oldRsaKeyPair.keyParams)) return oldRsaKeyPair;
         const rsaKeyPair = await this._computeRsaKeyPair(keyParams);
-        await this.setRsaKeyPair(rsaKeyPair, /* persist */ Key._areDefaultRsaKeyParams(keyParams));
+        await this.setRsaKeyPair(rsaKeyPair, /* persist */ Key._areRsaKeyParamsDefault(keyParams));
         return rsaKeyPair;
     }
 

--- a/src/lib/TransactionDataFormatting.js
+++ b/src/lib/TransactionDataFormatting.js
@@ -19,29 +19,29 @@ class TransactionDataFormatting { // eslint-disable-line no-unused-vars
             return I18n.translatePhrase('tx-data-funding-cashlink');
         }
 
-        // For regular transactions allow interpreting the data as utf8
+        let message = '';
+
+        // For transactions to basic accounts allow interpreting the data as utf8
+        // (the check for no flags is technically redundant, because the chain would
+        // reject any transaction to a basic account with flags)
         if (transaction.flags === Nimiq.TransactionFlag.None
-            && transaction.senderType === Nimiq.AccountType.Basic
             && transaction.recipientType === Nimiq.AccountType.Basic
-            && transaction.senderData.length === 0
             && Utf8Tools.isValidUtf8(transaction.data)) {
-            return Utf8Tools.utf8ByteArrayToString(transaction.data);
+            message = Utf8Tools.utf8ByteArrayToString(transaction.data);
         }
 
         const plainTransaction = transaction.toPlain();
         const plainData = plainTransaction.data;
 
-        // Contract withdrawal without any data
-        // If a transaction has no transaction data but a special sender type, try to give it a useful label nonetheless
-        if (transaction.senderData.length === 0
-            && transaction.data.length === 0
-            && transaction.senderType !== Nimiq.AccountType.Basic) {
-            return I18n.translatePhrase('tx-data-contract-withdrawal', {
+        let prefix = '';
+
+        // Contract withdrawal
+        if (transaction.senderType !== Nimiq.AccountType.Basic) {
+            prefix = I18n.translatePhrase('tx-data-contract-withdrawal', {
                 contractType: TransactionDataFormatting._capitalize(plainTransaction.senderType),
             });
         }
 
-        let prefix = '';
         let includeDataType = true;
 
         // Contract creation
@@ -59,15 +59,15 @@ class TransactionDataFormatting { // eslint-disable-line no-unused-vars
         } else if (transaction.recipientType === Nimiq.AccountType.Staking) {
             if (!(transaction.flags & Nimiq.TransactionFlag.Signaling)) { // eslint-disable-line no-bitwise
                 // A staking transaction which creates/adds actual stake by moving funds to the staking contract
-                prefix = I18n.translatePhrase('tx-data-contract-creation', { contractType: 'Staking' });
+                prefix = I18n.translatePhrase('tx-data-staking');
             } else {
                 // A staking signaling transaction which does not move funds but only updates the staking setup
                 prefix = I18n.translatePhrase('tx-data-staking-update');
             }
         }
 
-        const formattedPlainData = TransactionDataFormatting._formatPlainData(plainData, includeDataType);
-        const formattedData = [prefix, formattedPlainData].filter(entry => !!entry).join(': ');
+        const formattedPlainData = message || TransactionDataFormatting._formatPlainData(plainData, includeDataType);
+        const formattedData = [prefix, formattedPlainData].filter(Boolean).join(': ');
         return TransactionDataFormatting._capitalize(formattedData, true);
     }
 

--- a/src/lib/TransactionDataFormatting.js
+++ b/src/lib/TransactionDataFormatting.js
@@ -34,6 +34,7 @@ class TransactionDataFormatting { // eslint-disable-line no-unused-vars
         const plainData = plainTransaction.data;
 
         let prefix = '';
+        let includeDataType = true;
 
         // Contract withdrawal
         if (transaction.senderType !== Nimiq.AccountType.Basic) {
@@ -41,8 +42,6 @@ class TransactionDataFormatting { // eslint-disable-line no-unused-vars
                 contractType: TransactionDataFormatting._capitalize(plainTransaction.senderType),
             });
         }
-
-        let includeDataType = true;
 
         // Contract creation
         if (transaction.flags & Nimiq.TransactionFlag.ContractCreation) { // eslint-disable-line no-bitwise
@@ -53,10 +52,7 @@ class TransactionDataFormatting { // eslint-disable-line no-unused-vars
         }
 
         // Staking transaction
-        if (transaction.senderType === Nimiq.AccountType.Staking) {
-            // A staking withdrawal transaction. Those are never signaling transactions.
-            prefix = I18n.translatePhrase('tx-data-contract-withdrawal', { contractType: 'Staking' });
-        } else if (transaction.recipientType === Nimiq.AccountType.Staking) {
+        if (transaction.recipientType === Nimiq.AccountType.Staking) {
             if (!(transaction.flags & Nimiq.TransactionFlag.Signaling)) { // eslint-disable-line no-bitwise
                 // A staking transaction which creates/adds actual stake by moving funds to the staking contract
                 prefix = I18n.translatePhrase('tx-data-staking');

--- a/src/lib/rsa/sandboxed/RSAKeysIframe.js
+++ b/src/lib/rsa/sandboxed/RSAKeysIframe.js
@@ -30,7 +30,10 @@ function keyToUint8Array(key) {
 }
 
 window.addEventListener('message', async event => {
-    if (event.origin !== window.location.origin) return; // Reject messages from other origins
+    // Reject messages from other origins
+    if (event.origin !== window.location.origin) return;
+    // Ignore messages from the iframe itself (sometimes triggered by browser extensions)
+    if (event.source === event.target) return;
 
     /** @type {Command} */
     const data = event.data;

--- a/src/request/sign-multisig-transaction/SignMultisigTransaction.js
+++ b/src/request/sign-multisig-transaction/SignMultisigTransaction.js
@@ -266,7 +266,9 @@ class SignMultisigTransaction {
             }
         }
         if (ownCommitmentSecrets.length !== ownSigner.commitments.length) {
-            reject(new Errors.InvalidRequestError('The number of secrets does not match the number of my commitments'));
+            reject(new Errors.InvalidRequestError(
+                'The number of secrets does not match the number of this signer\'s commitments',
+            ));
             return;
         }
         /** @type {Nimiq.CommitmentPair[]} */

--- a/src/request/sign-multisig-transaction/SignMultisigTransaction.js
+++ b/src/request/sign-multisig-transaction/SignMultisigTransaction.js
@@ -244,6 +244,9 @@ class SignMultisigTransaction {
             reject(new Errors.InvalidRequestError('Selected key is not part of the multisig transaction signers'));
             return;
         }
+        // Get a list of other signers, excluding the own signer. This works because `ownSigner` is a reference into
+        // the `signers` array, so we can use object-equality.
+        const otherSigners = request.multisigConfig.signers.filter(signer => signer !== ownSigner);
 
         /** @type {Nimiq.RandomSecret[]} */
         let ownCommitmentSecrets;
@@ -284,7 +287,7 @@ class SignMultisigTransaction {
             request.keyPath,
             request.transaction.serializeContent(),
             ownCommitmentPairs,
-            request.multisigConfig.signers.filter(signer => signer !== ownSigner),
+            otherSigners,
         );
 
         /** @type {KeyguardRequest.SignMultisigTransactionResult} */

--- a/src/request/sign-multisig-transaction/SignMultisigTransaction.js
+++ b/src/request/sign-multisig-transaction/SignMultisigTransaction.js
@@ -17,7 +17,7 @@
 
 /**
  * @callback SignMultisigTransaction.resolve
- * @param {KeyguardRequest.SignMultisigTransactionResult} result
+ * @param {KeyguardRequest.SignatureResult} result
  */
 
 class SignMultisigTransaction {
@@ -290,7 +290,7 @@ class SignMultisigTransaction {
             otherSigners,
         );
 
-        /** @type {KeyguardRequest.SignMultisigTransactionResult} */
+        /** @type {KeyguardRequest.SignatureResult} */
         const result = {
             publicKey: publicKey.serialize(),
             signature: signature.serialize(),

--- a/src/request/sign-multisig-transaction/SignMultisigTransactionApi.js
+++ b/src/request/sign-multisig-transaction/SignMultisigTransactionApi.js
@@ -145,7 +145,7 @@ class SignMultisigTransactionApi extends TopLevelApi {
             && 'encrypted' in object.secrets && 'keyParams' in object.secrets) {
             if (!Array.isArray(object.secrets.encrypted)) {
                 // No need to check object.secrets.encrypted.length here, as the number will later be checked against
-                // the number of my provided commitments, after we identify them in SignMultisigTransaction.
+                // the number of this signer's provided commitments, after we identify them in SignMultisigTransaction.
                 throw new Errors.InvalidRequestError(
                     'Invalid secrets.encrypted: must be an array',
                 );

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -60,7 +60,7 @@ class SignTransactionApi extends TopLevelApi {
 
         if (parsedRequest.transaction.senderType === Nimiq.AccountType.Staking
             || parsedRequest.transaction.recipientType === Nimiq.AccountType.Staking) {
-            throw new Errors.InvalidRequestError('For staking transactions, use a Keyguard sign-staking request');
+            throw new Errors.InvalidRequestError('For staking transactions, use the Keyguard request "sign-staking"');
         }
 
         return parsedRequest;

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Unbekannt",
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Unknown",
 

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Desconocido",
 

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Inconnu",
 

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Onbekend",
 

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Desconhecido",
 

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Неизвестно",
 

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "Невідомо",
 

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -16,6 +16,7 @@
     "tx-data-funding-cashlink": "Funding cashlink",
     "tx-data-contract-creation": "{contractType} creation",
     "tx-data-contract-withdrawal": "{contractType} withdrawal",
+    "tx-data-staking": "Staking",
     "tx-data-staking-update": "Staking update",
     "label-unknown": "未知",
 

--- a/tests/lib/Key.spec.js
+++ b/tests/lib/Key.spec.js
@@ -57,57 +57,77 @@ describe('Key', () => {
         expect(key.deriveAddress('m/0\'').toUserFriendlyAddress()).toEqual(address2);
     });
 
-    // TODO: Update to new Key.signPartially() syntax
-    // it('can partially sign a multisig transaction (BIP39)', () => {
-    //     const keypairA = Nimiq.KeyPair.fromHex('14a3bc3b25c73b6ca3e829aef329a2a6dc69ae52b8d20a164831a021b6a9f9feec98d39d98a58c13d399673d6da7dc6c74f379eddd8c8628e40ffc6be7c2498300');
-    //     const keypairB = Nimiq.KeyPair.fromHex('2da15ede9992fad834b73283dd1a24f5a7a52b067b09be132ddb5232df863125bb639b6bbf6db003a94a83ef9d12f12fcc5990f63954b7f6d88f5be58f8c411200');
-    //     const keypairC = Nimiq.KeyPair.fromHex('a3b3d799e7fca4baa3568d58e0c909af1f832926020163a1d48998621a15c9c6b81b12bcb1a6e9ba49a6dec268705c2cc2d70d1d7e22493a4128559eadacdbd400');
+    it('can partially sign a multisig transaction (BIP39)', () => {
+        const keypairA = Nimiq.KeyPair.derive(Nimiq.PrivateKey.fromHex('14a3bc3b25c73b6ca3e829aef329a2a6dc69ae52b8d20a164831a021b6a9f9fe'));
+        const keypairB = Nimiq.KeyPair.derive(Nimiq.PrivateKey.fromHex('2da15ede9992fad834b73283dd1a24f5a7a52b067b09be132ddb5232df863125'));
+        const keypairC = Nimiq.KeyPair.derive(Nimiq.PrivateKey.fromHex('a3b3d799e7fca4baa3568d58e0c909af1f832926020163a1d48998621a15c9c6'));
 
-    //     const keyA = new Key(keypairA.privateKey);
-    //     const keyB = new Key(keypairB.privateKey);
-    //     const keyC = new Key(keypairC.privateKey);
+        const keyA = new Key(keypairA.privateKey);
+        const keyB = new Key(keypairB.privateKey);
+        const keyC = new Key(keypairC.privateKey);
 
-    //     const signerPublicKeys = [
-    //         keyA.derivePublicKey('m'),
-    //         keyB.derivePublicKey('m'),
-    //     ];
+        const signerPublicKeys = [
+            keyA.derivePublicKey('m'),
+            keyB.derivePublicKey('m'),
+        ];
 
-    //     const secretA = Nimiq.RandomSecret.deserialize(Nimiq.BufferUtils.fromHex('79c97389d2670f76d2e55192bc7ed875d9941bbfaa7932f8f452d9a907f94903'));
+        // The fixed hex strings have been generated with the multisig-app's Demo.vue page
 
-    //     const aggregatedCommitment = Nimiq.Commitment.deserialize(Nimiq.BufferUtils.fromHex('1c3eebbd316a7c46c7fb8359fd06ffa54ed77ff076de88ff429ae126d935482e'));
+        const transaction = Nimiq.Transaction.deserialize(Nimiq.BufferUtils.fromHex('01f4e305f34ea1ccf00c0f7fcbc030d1347dc5eafe0000e7741e4ae69075ec75b7779e787f22fbac594fa9000000000000000f4240000000000000000001613cca050000'));
 
-    //     const transaction = Nimiq.Transaction.deserialize(Nimiq.BufferUtils.fromHex('010000f4e305f34ea1ccf00c0f7fcbc030d1347dc5eafe00000000000000000000000000000000000000000000000000000000000a00000000000000000000000001000000'));
+        // Test if participants' public keys create the transaction's sender address
+        const expectedAddress = Nimiq.Address.fromPublicKeys([
+            keyA.derivePublicKey('m'),
+            keyB.derivePublicKey('m'),
+            keyC.derivePublicKey('m'),
+        ], 2);
 
-    //     // Test if participants' public keys create the transaction's sender address
-    //     const expectedAddress = Nimiq.Address.fromPublicKeys([
-    //         keyA.derivePublicKey('m'),
-    //         keyB.derivePublicKey('m'),
-    //         keyC.derivePublicKey('m'),
-    //     ], 2);
+        expect(transaction.sender.equals(expectedAddress)).toBe(true);
 
-    //     expect(transaction.sender.equals(expectedAddress)).toBe(true);
+        const commitmentPairsA = [
+            new Nimiq.CommitmentPair(
+                Nimiq.RandomSecret.fromHex("34e57d9589653e25474403e14a06a8a27f3b96767497a2a3fc8ff787a8f0ed0a"),
+                Nimiq.Commitment.fromHex("30ed83f0ea0f6ca1a0a087dac6d6f7b3c61459ae0489b4aa57aae6ac92f79647"),
+            ),
+            new Nimiq.CommitmentPair(
+                Nimiq.RandomSecret.fromHex("ca35586032118b1f9ac0655ead843cea423c0e6590240b2c416da625cdb6f50b"),
+                Nimiq.Commitment.fromHex("665c9a9010fda255d5765af22194a4039a86bae2335433c8a93628c1d26da002"),
+            ),
+        ];
 
-    //     const partialSignatureA = keyA.signPartially(
-    //         'm',
-    //         transaction.serializeContent(),
-    //         signerPublicKeys,
-    //         secretA,
-    //         aggregatedCommitment,
-    //     );
+        const commitmentPairsB = [
+            new Nimiq.CommitmentPair(
+                Nimiq.RandomSecret.fromHex("218f4e3f2b136f75ff5b5e7a23f154993a0f1ca174853f3fdc533d09f3d42d08"),
+                Nimiq.Commitment.fromHex("43bbd3695d2d53f121b585a4d5a4c4edf878934a0b811fa6334b79f790a80908"),
+            ),
+            new Nimiq.CommitmentPair(
+                Nimiq.RandomSecret.fromHex("51ed42bb96c5a6058f7cb0056dac059cd7225b9a991b4b442d3d4c9d71caac01"),
+                Nimiq.Commitment.fromHex("3de45bb9f05349abffa74707b44d7eaa3588cbe3da0629bac5bc2b7333a6858b"),
+            ),
+        ];
 
-    //     expect(partialSignatureA.toHex()).toEqual('b3584f24b073410d9c6f8c092068a2d1b66e67387fa3319e57609f2b2425be02');
+        const partialSignatureA = keyA.signPartially(
+            'm',
+            transaction.serializeContent(),
+            commitmentPairsA,
+            [{
+                publicKey: signerPublicKeys[1],
+                commitments: commitmentPairsB.map(pair => pair.commitment),
+            }],
+        );
 
+        expect(partialSignatureA.toHex()).toEqual('40ac7aeb69d2ad7e6418bfc289a18950ef6c10b9198f075cc6afbf6c51a6ef07');
 
-    //     const secretB = Nimiq.RandomSecret.deserialize(Nimiq.BufferUtils.fromHex('0e400561be5711fc7d39d24774233419fb99b7421a86e0520b98d5399a6a5801'));
+        const partialSignatureB = keyB.signPartially(
+            'm',
+            transaction.serializeContent(),
+            commitmentPairsB,
+            [{
+                publicKey: signerPublicKeys[0],
+                commitments: commitmentPairsA.map(pair => pair.commitment),
+            }],
+        );
 
-    //     const partialSignatureB = keyB.signPartially(
-    //         'm',
-    //         transaction.serializeContent(),
-    //         signerPublicKeys,
-    //         secretB,
-    //         aggregatedCommitment,
-    //     );
-
-    //     expect(partialSignatureB.toHex()).toEqual('caa6353261d250e2f1f67499f526c47503015e08d2a69169322fecae83cdf607');
-    // })
+        expect(partialSignatureB.toHex()).toEqual('1705344a6421a7010dbf6db6410d1e7f0f1eaaa65afb80d6404cf0e8d064db06');
+    })
 });

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -196,6 +196,10 @@ describe('RequestParser', () => {
 
         expect(requestParser.parseLogoUrl(undefined, true, 'shopLogoUrl')).toBe(undefined);
 
+        // Test allowEmpty = false
+        expect(() => requestParser.parseLogoUrl('http://exampleshop.com/image.png', false, 'shopLogoUrl')).not.toThrow();
+        expect(() => requestParser.parseLogoUrl(undefined, false, 'shopLogoUrl')).toThrow();
+
         const vectors = [
             ['http://exampleshop.com/image.png', 'http://exampleshop.com/image.png'],
             ['https://nimiq.com/some/path/some/where/index.jpg?foo=bar', 'https://nimiq.com/some/path/some/where/index.jpg?foo=bar'],

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -362,9 +362,13 @@ cp dist/index.html dist/request
 
 # Build RSA iframe
 output "🔑  Building RSA Iframe"
+
+# Integrity check that forge.min.js is from node-forge 1.3.1
+nodeforge_hashsum="dc67fd132427ad96c9666c844b39565413c40ddb1f2d063c53512fbf6d387dfd  src/lib/rsa/sandboxed/forge.min.js"
+echo "$nodeforge_hashsum" | ${SHA256SUM} --check
+
 cp src/lib/rsa/sandboxed/forge.min.js dist/lib/rsa/sandboxed/forge.min.HASH.js
-# Integirty check that forge.min.js is from node-forge 1.3.1
-RSA_IFRAME_FORGE_HASH="3Gf9EyQnrZbJZmyESzlWVBPEDdsfLQY8U1Evv204ff0="
+RSA_IFRAME_FORGE_HASH=$(make_file_hash dist/lib/rsa/sandboxed/forge.min.HASH.js)
 RSA_IFRAME_FORGE_NAME=$(add_hash_to_file_name dist/lib/rsa/sandboxed/forge.min.HASH.js)
 cp src/lib/rsa/sandboxed/RSAKeysIframe.js dist/lib/rsa/sandboxed/RSAKeysIframe.HASH.js
 RSA_IFRAME_SCRIPT_HASH=$(make_file_hash dist/lib/rsa/sandboxed/RSAKeysIframe.HASH.js)


### PR DESCRIPTION
Some changes for the review I made on #524:

- Change transaction data formatting logic to always show a message when the tx is to a BASIC account (and also the contract withdrawal prefix if it is a withdrawal)
- Minor reword of some error messages, comments and method names
- Verify `forge.min.js` file integrity during build, not only at runtime
- Move filtering of other signers to right behind the search for the own signer, to make it clearer that object comparison can be used there.