### PR TITLE
Update Tether domain name 

### DIFF
--- a/src/lib/polygon/PolygonKey.js
+++ b/src/lib/polygon/PolygonKey.js
@@ -110,7 +110,7 @@ class PolygonKey { // eslint-disable-line no-unused-vars
 
         // TODO: Make the domain parameters configurable in the request?
         const domain = {
-            name: '(PoS) Tether USD', // This is currently the same for testnet and mainnet
+            name: 'USDT0', // This is currently the same for testnet(?) and mainnet
             version: '1', // This is currently the same for testnet and mainnet
             verifyingContract: CONFIG.BRIDGED_USDT_CONTRACT_ADDRESS,
             salt: ethers.utils.hexZeroPad(ethers.utils.hexlify(CONFIG.POLYGON_CHAIN_ID), 32),


### PR DESCRIPTION
Following the change from bridged to native token on Polygon:
https://polygon.technology/blog/native-usdt0-comes-to-polygon-for-lower-fees-and-deeper-liquidity

I tested this in mainnet by making this change in the browser devtools source editor before entering my password, leading to a successful transaction.