### PR TITLE
Inline RSA IFrame scripts during build

### DIFF
--- a/src/lib/rsa/sandboxed/RSAKeysIframe.html
+++ b/src/lib/rsa/sandboxed/RSAKeysIframe.html
@@ -12,11 +12,15 @@
         script-src 'self';
     ">
     <title>RSA Keys Iframe</title>
-    <script src="./forge.min.js"></script>
+    <script src="./forge.min.js">
+        // RSA_IFRAME_FORGE_CONTENTS
+    </script>
 </head>
 <body>
     RSA Keys Iframe <span id="loading"></span>
 
-    <script src="./RSAKeysIframe.js"></script>
+    <script src="./RSAKeysIframe.js">
+        // RSA_IFRAME_SCRIPT_CONTENTS
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Loading scripts from *.nimiq.com by a cross-origin page is blocked by adblockers. And the sandboxed iframe counts as another origin.