### PR TITLE
Strip stack traces from RPC error responses (OAC-05)

### DIFF
--- a/src/lib/RpcServer.es.js
+++ b/src/lib/RpcServer.es.js
@@ -148,9 +148,9 @@ class RpcState {
     reply(status, result) {
         console.debug('RpcServer REPLY', result);
         if (status === ResponseStatus.ERROR) {
-            // serialize error objects
+            // serialize error objects, omitting stack traces to avoid leaking internal details
             result = typeof result === 'object'
-                ? { message: result.message, stack: result.stack, name: result.name }
+                ? { message: result.message, name: result.name }
                 : { message: result };
         }
         if (this._postMessage) {


### PR DESCRIPTION
## Summary
- Removes the `stack` property from error objects serialized in `RpcState.reply()` (`src/lib/RpcServer.es.js`)
- Prevents internal file paths, line numbers, and code structure from leaking to callers via `postMessage` or URL-encoded redirect responses
- The full error (including stack trace) remains available in `console.debug` for development/debugging

## Security Finding
**OAC-05 (LOW):** Error stack traces were included in RPC error responses sent back to the calling origin. For redirect responses, this meant error details (including internal file paths and code structure) appeared in the URL fragment. While URL fragments are not sent to servers, they may appear in browser history and could be accessible to the receiving page's JavaScript.

## Changes
- `src/lib/RpcServer.es.js:152-153` — Removed `stack` from the serialized error object, now only sending `message` and `name`

## Test plan
- [ ] Trigger an RPC error (e.g., invalid request) and verify the error response contains `message` and `name` but no `stack`
- [ ] Verify `console.debug` still logs the full error with stack trace
- [ ] Verify redirect error responses do not contain stack trace in URL fragment
- [ ] Confirm the Keyguard client (Hub) handles errors correctly without the `stack` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)