### PR TITLE
Fix IV-01: Add input validation to IFrameApi

### DIFF
--- a/src/request/iframe/IFrameApi.js
+++ b/src/request/iframe/IFrameApi.js
@@ -33,6 +33,21 @@ class IFrameApi {
      * @returns {Promise<KeyguardRequest.DerivedAddress[]>}
      */
     async deriveAddresses(state, request) {
+        if (!request.keyId || typeof request.keyId !== 'string') {
+            throw new Errors.InvalidRequestError('keyId must be a string');
+        }
+        if (!request.paths || !Array.isArray(request.paths)) {
+            throw new Errors.InvalidRequestError('paths must be an array');
+        }
+        if (request.paths.length === 0) {
+            throw new Errors.InvalidRequestError('paths must not be empty');
+        }
+        request.paths.forEach((path, i) => {
+            if (!path || typeof path !== 'string' || !Nimiq.ExtendedPrivateKey.isValidPath(path)) {
+                throw new Errors.InvalidRequestError(`paths[${i}]: Invalid path`);
+            }
+        });
+
         const storedEntropy = await NonPartitionedSessionStorage.get(
             IFrameApi.SESSION_STORAGE_KEY_PREFIX + request.keyId,
             request.tmpCookieEncryptionKey,
@@ -59,6 +74,11 @@ class IFrameApi {
      * @returns {Promise<KeyguardRequest.SimpleResult>}
      */
     async releaseKey(state, request) {
+        if (!request.keyId || typeof request.keyId !== 'string') {
+            throw new Errors.InvalidRequestError('keyId must be a string');
+        }
+        request.shouldBeRemoved = !!request.shouldBeRemoved;
+
         if (request.shouldBeRemoved
             && NonPartitionedSessionStorage.has(IFrameApi.SESSION_STORAGE_KEY_PREFIX + request.keyId)) {
             if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {


### PR DESCRIPTION
## Summary

- Add input validation to `IFrameApi.deriveAddresses()` and `IFrameApi.releaseKey()`, closing a defense-in-depth gap where these methods accepted unvalidated request parameters unlike `TopLevelApi` which uses `RequestParser`
- Validates `keyId` as non-empty string, `paths` as non-empty array of valid BIP44 paths, and coerces `shouldBeRemoved` to boolean
- Prevents DoS via null/malformed paths, cookie poisoning on Safari via non-string keyId, and session storage manipulation

## Details

`IFrameApi` methods had no input validation, while `TopLevelApi` uses comprehensive `RequestParser` checks (`parseKeyId`, `parsePathsArray`, `parsePath`). A compromised Hub origin could exploit this to:

1. **Crash** the iframe by passing `paths: null` (TypeError on `.map()`)
2. **Corrupt Safari cookies** by passing a non-string `keyId` (injected into JSON cookie via `CookieJar.writeCookie`)
3. **Delete session keys** for arbitrary key IDs without type checking

The fix adds the same validation patterns used by `RequestParser` directly in the IFrameApi methods.

## Test plan

- [ ] Lint passes (verified: 0 errors)
- [ ] Verify `deriveAddresses` rejects: `keyId` as non-string, `paths` as null/string/empty array, invalid BIP44 paths
- [ ] Verify `releaseKey` rejects: `keyId` as non-string
- [ ] Verify `releaseKey` coerces `shouldBeRemoved` to boolean
- [ ] Verify normal wallet flows (login, address derivation, key release) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)